### PR TITLE
truffle 관련 설정 application.yml 에서 제거

### DIFF
--- a/core/src/main/resources/application-common.yml
+++ b/core/src/main/resources/application-common.yml
@@ -25,19 +25,6 @@ google:
         bundle-id:
         app-store-id:
 
-truffle:
-  client:
-    name: snutt-timetable
-    phase: local
-    api-key:
-    dynamic-link:
-      domain-uri-prefix:
-      android:
-        package-name:
-      ios:
-        bundle-id:
-        app-store-id:
-
 http:
   response-timeout: 3s
 
@@ -71,9 +58,6 @@ google:
         bundle-id:
         app-store-id:
 
-truffle:
-  enabled: true
-
 ---
 
 spring:
@@ -100,8 +84,5 @@ google:
       ios:
         bundle-id:
         app-store-id:
-
-truffle:
-  enabled: true
 
 secret-names: prod/snutt-timetable

--- a/core/src/test/resources/application.yaml
+++ b/core/src/test/resources/application.yaml
@@ -10,12 +10,6 @@ logging:
 
 de.flapdoodle.mongodb.embedded.version: 5.0.5
 
-truffle:
-  client:
-    name: snutt-timetable
-    phase: test
-    api-key: test-api-key
-
 google:
   firebase:
     project-id:


### PR DESCRIPTION
deprecated 된 property 넣고 있는 것 제거 (dynamic-link 설정을 왜 truffle 하위에도 넣으셨는지? ㅋㅋㅋ @subeenpark-io)

`truffle.enabled`는 waffle-world env 설정으로 `TRUFFLE_ENABLED`를 넣으려고 함. 로컬에서 truffle false alert 가는 경우 없게.

wafflestudio/waffle-world/pull/73