### PR TITLE
강의 업데이트 시 강의동 정보가 날아가지 않도록 수정

### DIFF
--- a/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.snu4t.common.exception.LectureNotFoundException
 import com.wafflestudio.snu4t.common.exception.LectureTimeOverlapException
 import com.wafflestudio.snu4t.common.exception.TimetableNotFoundException
 import com.wafflestudio.snu4t.common.exception.WrongSemesterException
+import com.wafflestudio.snu4t.lectures.data.Lecture
 import com.wafflestudio.snu4t.lectures.repository.LectureRepository
 import com.wafflestudio.snu4t.lectures.utils.ClassTimeUtils
 import com.wafflestudio.snu4t.timetables.data.Timetable
@@ -117,9 +118,21 @@ class TimetableLectureServiceImpl(
             remark = modifyTimetableLectureRequestDto.remark ?: remark
             color = modifyTimetableLectureRequestDto.color ?: color
             colorIndex = modifyTimetableLectureRequestDto.colorIndex ?: colorIndex
-            classPlaceAndTimes = modifyTimetableLectureRequestDto.classPlaceAndTimes?.map { it.toClassPlaceAndTime() } ?: classPlaceAndTimes
+            classPlaceAndTimes = modifyTimetableLectureRequestDto.classPlaceAndTimes?.map {
+                it.toClassPlaceAndTime()
+            } ?: classPlaceAndTimes
+        }.apply {
+            val lecture = timetableLecture.lectureId?.let { lectureRepository.findById(it) }
+
+            classPlaceAndTimes = classPlaceAndTimes.mapIndexed { index, classPlaceAndTime ->
+                classPlaceAndTime.apply {
+                    this.lectureBuilding = lecture?.classPlaceAndTimes?.getOrNull(index)?.lectureBuilding
+                }
+            }
         }
+
         resolveTimeConflict(timetable, timetableLecture, isForced)
+
         return timetableRepository.updateTimetableLecture(timetableId, timetableLecture)
     }
 

--- a/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
@@ -7,7 +7,6 @@ import com.wafflestudio.snu4t.common.exception.LectureNotFoundException
 import com.wafflestudio.snu4t.common.exception.LectureTimeOverlapException
 import com.wafflestudio.snu4t.common.exception.TimetableNotFoundException
 import com.wafflestudio.snu4t.common.exception.WrongSemesterException
-import com.wafflestudio.snu4t.lectures.data.Lecture
 import com.wafflestudio.snu4t.lectures.repository.LectureRepository
 import com.wafflestudio.snu4t.lectures.utils.ClassTimeUtils
 import com.wafflestudio.snu4t.timetables.data.Timetable

--- a/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
@@ -125,7 +125,7 @@ class TimetableLectureServiceImpl(
 
             classPlaceAndTimes = classPlaceAndTimes.mapIndexed { index, classPlaceAndTime ->
                 classPlaceAndTime.apply {
-                    this.lectureBuilding = lecture?.classPlaceAndTimes?.getOrNull(index)?.lectureBuilding
+                    this.lectureBuildings = lecture?.classPlaceAndTimes?.getOrNull(index)?.lectureBuildings
                 }
             }
         }


### PR DESCRIPTION
강의 편집 시 강의동 날라가는 문제 해결
- https://wafflestudio.slack.com/archives/C0PAVPS5T/p1706674552129189?thread_ts=1706543742.221119&cid=C0PAVPS5T