### PR TITLE
Revert "강의 데이터 반환 전에 빌딩 정보 매핑"

### DIFF
--- a/api/src/main/kotlin/handler/LectureSearchHandler.kt
+++ b/api/src/main/kotlin/handler/LectureSearchHandler.kt
@@ -3,16 +3,11 @@ package com.wafflestudio.snu4t.handler
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snu4t.common.enum.DayOfWeek
 import com.wafflestudio.snu4t.common.enum.Semester
-import com.wafflestudio.snu4t.lecturebuildings.data.PlaceInfo
-import com.wafflestudio.snu4t.lecturebuildings.service.LectureBuildingService
 import com.wafflestudio.snu4t.lectures.dto.LectureDto
 import com.wafflestudio.snu4t.lectures.dto.SearchDto
 import com.wafflestudio.snu4t.lectures.dto.SearchTimeDto
 import com.wafflestudio.snu4t.lectures.service.LectureService
 import com.wafflestudio.snu4t.middleware.SnuttRestApiNoAuthMiddleware
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -22,7 +17,6 @@ import org.springframework.web.reactive.function.server.awaitBody
 @Component
 class LectureSearchHandler(
     private val lectureService: LectureService,
-    private val lectureBuildingService: LectureBuildingService,
     snuttRestApiNoAuthMiddleware: SnuttRestApiNoAuthMiddleware,
 ) : ServiceHandler(
     handlerMiddleware = snuttRestApiNoAuthMiddleware
@@ -30,20 +24,6 @@ class LectureSearchHandler(
     suspend fun searchLectures(req: ServerRequest): ServerResponse = handle(req) {
         val query: SearchQueryLegacy = req.awaitBody()
         lectureService.search(query.toSearchDto()).toList().map { LectureDto(it) }
-            .map { it.addLectureBuildings() }
-    }
-
-    private suspend fun LectureDto.addLectureBuildings(): LectureDto = coroutineScope {
-        copy(
-            classPlaceAndTimes = classPlaceAndTimes.map { classPlaceAndTime ->
-                async {
-                    classPlaceAndTime.apply {
-                        lectureBuildings =
-                            place?.let { lectureBuildingService.getLectureBuildings(PlaceInfo.getValuesOf(it)) }
-                    }
-                }
-            }.awaitAll()
-        )
     }
 }
 

--- a/core/src/main/kotlin/lectures/dto/ClassPlaceAndTimeDto.kt
+++ b/core/src/main/kotlin/lectures/dto/ClassPlaceAndTimeDto.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snu4t.lectures.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snu4t.common.enum.DayOfWeek
-import com.wafflestudio.snu4t.lecturebuildings.data.LectureBuilding
 import com.wafflestudio.snu4t.lectures.data.ClassPlaceAndTime
 import com.wafflestudio.snu4t.lectures.utils.endPeriod
 import com.wafflestudio.snu4t.lectures.utils.minuteToString
@@ -35,7 +34,6 @@ data class ClassPlaceAndTimeLegacyDto(
     val periodLength: Double,
     @JsonProperty("start")
     val startPeriod: Double,
-    var lectureBuildings: List<LectureBuilding>? = null,
 )
 
 fun ClassPlaceAndTimeLegacyDto(classPlaceAndTime: ClassPlaceAndTime): ClassPlaceAndTimeLegacyDto = ClassPlaceAndTimeLegacyDto(


### PR DESCRIPTION
This reverts commit b547b59205d04fe49e10ded6f07cfa12dc63c315.

lecture, timetableLecture 둘 다 반환 전에 building 정보 매핑해서 내려줌
새 api 사용하도록 유도하고 building 매핑 롤백