### PR TITLE
친구 링크 유효하지 않을 때 에러 메시지 수정

### DIFF
--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -64,6 +64,7 @@ enum class ErrorType(
     THEME_NOT_FOUND(HttpStatus.NOT_FOUND, 40406, "테마를 찾을 수 없습니다.", "테마를 찾을 수 없습니다."),
     EV_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, 40407, "강의평 데이터를 찾을 수 없습니다.", "강의평 데이터를 찾을 수 없습니다."),
     TAG_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 40408, "태그 리스트를 찾을 수 없습니다.", "태그 리스트를 찾을 수 없습니다."),
+    FRIEND_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, 40409, "친구 링크가 유효하지 않습니다.", "친구 링크가 유효하지 않습니다."),
 
     DUPLICATE_VACANCY_NOTIFICATION(HttpStatus.CONFLICT, 40900, "빈자리 알림 중복"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, 40901, "이미 사용 중인 이메일입니다.", "이미 사용 중인 이메일입니다."),

--- a/core/src/main/kotlin/common/exception/Snu4tException.kt
+++ b/core/src/main/kotlin/common/exception/Snu4tException.kt
@@ -110,6 +110,8 @@ object ConfigNotFoundException : Snu4tException(ErrorType.CONFIG_NOT_FOUND)
 
 object FriendNotFoundException : Snu4tException(ErrorType.FRIEND_NOT_FOUND)
 
+object FriendLinkNotFoundException : Snu4tException(ErrorType.FRIEND_LINK_NOT_FOUND)
+
 object UserNotFoundByNicknameException : Snu4tException(ErrorType.USER_NOT_FOUND_BY_NICKNAME)
 
 object ThemeNotFoundException : Snu4tException(ErrorType.THEME_NOT_FOUND)

--- a/core/src/main/kotlin/friend/service/FriendService.kt
+++ b/core/src/main/kotlin/friend/service/FriendService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snu4t.friend.service
 
 import com.wafflestudio.snu4t.common.exception.DuplicateFriendException
+import com.wafflestudio.snu4t.common.exception.FriendLinkNotFoundException
 import com.wafflestudio.snu4t.common.exception.FriendNotFoundException
 import com.wafflestudio.snu4t.common.exception.InvalidDisplayNameException
 import com.wafflestudio.snu4t.common.exception.InvalidFriendException
@@ -232,7 +233,7 @@ class FriendServiceImpl(
     ): Pair<Friend, User> {
         val fromUserId =
             redisTemplate.opsForValue()
-                .getAndAwait(FRIEND_LINK_REDIS_PREFIX + requestToken) ?: throw FriendNotFoundException
+                .getAndAwait(FRIEND_LINK_REDIS_PREFIX + requestToken) ?: throw FriendLinkNotFoundException
         val fromUser = userRepository.findByIdAndActiveTrue(fromUserId) ?: throw UserNotFoundException
         if (fromUser.id == userId) {
             throw InvalidFriendException


### PR DESCRIPTION
RN에서 에러 메시지를 그대로 띄우고 있어서 명확하게 수정했습니다