### PR TITLE
flushCache 사용처 및 메소드 삭제

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/job/sync/SugangSnuSyncJobConfig.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/SugangSnuSyncJobConfig.kt
@@ -48,7 +48,6 @@ class SugangSnuSyncJobConfig {
                         sugangSnuSyncService.addCoursebook(newCoursebook)
                         sugangSnuNotificationService.notifyCoursebookUpdate(newCoursebook)
                     }
-                    sugangSnuSyncService.flushCache()
                 }
                 RepeatStatus.FINISHED
             },

--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -41,8 +41,6 @@ interface SugangSnuSyncService {
     suspend fun addCoursebook(coursebook: Coursebook)
 
     suspend fun isSyncWithSugangSnu(latestCoursebook: Coursebook): Boolean
-
-    suspend fun flushCache()
 }
 
 @Service
@@ -84,8 +82,6 @@ class SugangSnuSyncServiceImpl(
         val sugangSnuLatestCoursebook = sugangSnuRepository.getCoursebookCondition()
         return latestCoursebook.isSyncedToSugangSnu(sugangSnuLatestCoursebook)
     }
-
-    override suspend fun flushCache() = cache.flushDatabase()
 
     private fun compareLectures(
         newLectures: Iterable<Lecture>,

--- a/core/src/main/kotlin/common/cache/Cache.kt
+++ b/core/src/main/kotlin/common/cache/Cache.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactive.awaitSingle
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.data.redis.core.deleteAndAwait
@@ -33,8 +32,6 @@ interface Cache {
     suspend fun acquireLock(builtKey: BuiltCacheKey): Boolean
 
     suspend fun releaseLock(builtKey: BuiltCacheKey): Boolean
-
-    suspend fun flushDatabase()
 }
 
 @Component
@@ -103,10 +100,6 @@ class RedisCache(
     override suspend fun releaseLock(builtKey: BuiltCacheKey): Boolean {
         log.debug("[CACHE DEL] {}", builtKey.key)
         return redisTemplate.deleteAndAwait(builtKey.key) > 0
-    }
-
-    override suspend fun flushDatabase() {
-        redisTemplate.execute { it.serverCommands().flushDb() }.awaitSingle()
     }
 }
 


### PR DESCRIPTION
### 이슈
- 배치 돌 때마다 친구추가 링크가 만료됨
- 배치에서 현재 redis flushDb 호출
- 원래 강의 검색결과 캐시만 redis에 존재 할 때 넣은 스펙

### 변경사항
- 강의 검색결과 캐시가 사라지면서 지울 데이터가 없으므로 배치에서 flushDb 삭제
- 다른데서도 호출되는 경우 없도록 아예 메소드 삭제