### PR TITLE
엔터 들어올때 피드백 형식 안깨지게 수정

### DIFF
--- a/core/src/main/kotlin/feedback/dto/FeedbackDto.kt
+++ b/core/src/main/kotlin/feedback/dto/FeedbackDto.kt
@@ -16,7 +16,5 @@ data class FeedbackDto(
         버전: $appVersion
         프로필: $profileName
         날짜/시간(UTC+9): $currentSeoulTime
-            
-        $message
-        """.trimIndent()
+        """.trimIndent() + "\n\n" + message
 }


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C8M9NUBBR/p1730184805341109 이거처럼 trimindent가 제대로 적용 안되는 경우가 있어서  message를 따로 합치도록 분리했습니다