### PR TITLE
presentUser가 null인 경우 오류 발생 수정

### DIFF
--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -401,7 +401,7 @@ class UserServiceImpl(
         if (oauth2UserResponse.email != null) {
             val presentUser = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)
             if (presentUser != null && presentUser.id != user.id) {
-                throw DuplicateEmailException(getAttachedAuthProviders(user))
+                throw DuplicateEmailException(getAttachedAuthProviders(presentUser))
             }
         }
 

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -400,7 +400,7 @@ class UserServiceImpl(
         val oauth2UserResponse = authService.socialLoginWithAccessToken(authProvider, token)
         if (oauth2UserResponse.email != null) {
             val presentUser = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)
-            if (presentUser?.id != user.id) {
+            if (presentUser != null && presentUser.id != user.id) {
                 throw DuplicateEmailException(getAttachedAuthProviders(user))
             }
         }


### PR DESCRIPTION
https://github.com/wafflestudio/snutt-timetable/pull/295 에서 presentUser가 null인 경우 에러를 띄우게 돼서 다시 원래대로 바꿨습니다
또 presentUser에 대해 social provider 목록을 제공하는게 맞을거 같아 그것도 바꿨습니다