### PR TITLE
Feature/apple login migration

### DIFF
--- a/api/src/main/kotlin/handler/AuthHandler.kt
+++ b/api/src/main/kotlin/handler/AuthHandler.kt
@@ -61,6 +61,12 @@ class AuthHandler(
             userService.loginKakao(socialLoginRequest)
         }
 
+    suspend fun loginApple(req: ServerRequest): ServerResponse =
+        handle(req) {
+            val socialLoginRequest: SocialLoginRequest = req.awaitBodyOrNull() ?: throw ServerWebInputException("Invalid body")
+            userService.loginApple(socialLoginRequest)
+        }
+
     suspend fun logout(req: ServerRequest): ServerResponse =
         handle(req) {
             val userId = req.userId

--- a/api/src/main/kotlin/router/MainRouter.kt
+++ b/api/src/main/kotlin/router/MainRouter.kt
@@ -86,6 +86,7 @@ class MainRouter(
                 POST("/login/facebook", authHandler::loginFacebook)
                 POST("/login/google", authHandler::loginGoogle)
                 POST("/login/kakao", authHandler::loginKakao)
+                POST("/login/apple", authHandler::loginApple)
                 POST("/logout", authHandler::logout)
                 POST("/password/reset/email/check", authHandler::getMaskedEmail)
                 POST("/password/reset/email/send", authHandler::sendResetPasswordCode)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation("software.amazon.awssdk:sts:2.25.15")
     implementation("software.amazon.awssdk:ses:2.25.15")
     implementation("com.google.firebase:firebase-admin:9.3.0")
+    implementation("io.jsonwebtoken:jjwt:0.9.1")
 
     testFixturesImplementation("org.testcontainers:mongodb:1.19.0")
     testFixturesImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")

--- a/core/src/main/kotlin/auth/OAuth2UserResponse.kt
+++ b/core/src/main/kotlin/auth/OAuth2UserResponse.kt
@@ -5,4 +5,5 @@ data class OAuth2UserResponse(
     val name: String?,
     val email: String?,
     val isEmailVerified: Boolean,
+    val transferInfo: String? = null,
 )

--- a/core/src/main/kotlin/auth/apple/AppleClient.kt
+++ b/core/src/main/kotlin/auth/apple/AppleClient.kt
@@ -1,0 +1,86 @@
+package com.wafflestudio.snu4t.auth.apple
+
+import com.wafflestudio.snu4t.auth.OAuth2Client
+import com.wafflestudio.snu4t.auth.OAuth2UserResponse
+import com.wafflestudio.snu4t.common.extension.get
+import com.wafflestudio.snu4t.users.repository.UserRepository
+import io.jsonwebtoken.Jwts
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.time.Duration
+import java.util.Base64
+
+@Component("APPLE")
+class AppleClient(
+    webClientBuilder: WebClient.Builder,
+    private val userRepository: UserRepository,
+) : OAuth2Client {
+    private val webClient =
+        webClientBuilder.clientConnector(
+            ReactorClientHttpConnector(
+                HttpClient.create().responseTimeout(
+                    Duration.ofSeconds(3),
+                ),
+            ),
+        ).build()
+
+    companion object {
+        private const val APPLE_JWK_URI = "https://appleid.apple.com/auth/keys"
+    }
+
+    override suspend fun getMe(token: String): OAuth2UserResponse? {
+        val jwtHeader = extractJwtHeader(token)
+        val appleJwk =
+            webClient.get<List<AppleJwk>>(uri = APPLE_JWK_URI).getOrNull()
+                ?.firstOrNull {
+                    it.kid == jwtHeader.keyId && it.alg == jwtHeader.algorithm
+                } ?: return null
+        val publicKey = convertJwkToPublicKey(appleJwk)
+        val jwtPayload = verifyAndDecodeToken(token, publicKey)
+        val appleUserInfo = AppleUserInfo(jwtPayload)
+        if (appleUserInfo.transferSub != null) {
+            transferAppleCredential(appleUserInfo.transferSub, appleUserInfo.sub, appleUserInfo.email)
+        }
+        return OAuth2UserResponse(
+            socialId = appleUserInfo.sub,
+            name = null,
+            email = appleUserInfo.email,
+            isEmailVerified = appleUserInfo.emailVerified ?: true,
+        )
+    }
+
+    private suspend fun extractJwtHeader(token: String) = Jwts.parser().parseClaimsJws(token).header
+
+    private suspend fun convertJwkToPublicKey(jwk: AppleJwk): PublicKey {
+        val modulus = BigInteger(1, Base64.getUrlDecoder().decode(jwk.n))
+        val exponent = BigInteger(1, Base64.getUrlDecoder().decode(jwk.e))
+        val spec = RSAPublicKeySpec(modulus, exponent)
+        return KeyFactory.getInstance("RSA").generatePublic(spec)
+    }
+
+    private suspend fun verifyAndDecodeToken(
+        token: String,
+        publicKey: PublicKey,
+    ) = Jwts.parser().setSigningKey(publicKey).parseClaimsJws(token).body
+
+    private suspend fun transferAppleCredential(
+        transferSub: String,
+        sub: String,
+        email: String?,
+    ) {
+        userRepository.findByCredentialAppleTransferSubAndActiveTrue(transferSub)?.let {
+            it.credential.apply {
+                appleSub = sub
+                appleEmail = email
+                appleTransferSub = transferSub
+            }
+            userRepository.save(it)
+        }
+    }
+}

--- a/core/src/main/kotlin/auth/apple/AppleJwk.kt
+++ b/core/src/main/kotlin/auth/apple/AppleJwk.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.snu4t.auth.apple
+
+data class AppleJwk(
+    val kty: String,
+    val kid: String,
+    val use: String,
+    val alg: String,
+    val n: String,
+    val e: String,
+)

--- a/core/src/main/kotlin/auth/apple/AppleUserInfo.kt
+++ b/core/src/main/kotlin/auth/apple/AppleUserInfo.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.snu4t.auth.apple
+
+import io.jsonwebtoken.Claims
+
+data class AppleUserInfo(
+    val sub: String,
+    val email: String?,
+    val emailVerified: Boolean?,
+    val transferSub: String?,
+) {
+    constructor(jwtPayload: Claims) : this(
+        sub = jwtPayload.subject,
+        email = jwtPayload["email"] as? String,
+        emailVerified = jwtPayload["email_verified"] as? Boolean,
+        transferSub = jwtPayload["transfer_sub"] as? String,
+    )
+}

--- a/core/src/main/kotlin/feedback/dto/FeedbackDto.kt
+++ b/core/src/main/kotlin/feedback/dto/FeedbackDto.kt
@@ -16,7 +16,5 @@ data class FeedbackDto(
         버전: $appVersion
         프로필: $profileName
         날짜/시간(UTC+9): $currentSeoulTime
-            
-        $message
-        """.trimIndent()
+        """.trimIndent() + "\n\n" + message
 }

--- a/core/src/main/kotlin/users/dto/SocialLoginRequest.kt
+++ b/core/src/main/kotlin/users/dto/SocialLoginRequest.kt
@@ -1,5 +1,8 @@
 package com.wafflestudio.snu4t.users.dto
 
+import com.fasterxml.jackson.annotation.JsonAlias
+
 data class SocialLoginRequest(
+    @JsonAlias("fb_token")
     val token: String,
 )

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -20,9 +20,11 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findByCredentialFbIdAndActiveTrue(fbId: String): User?
 
-    suspend fun findByCredentialGoogleSubAndActiveTrue(fbId: String): User?
+    suspend fun findByCredentialGoogleSubAndActiveTrue(googleSub: String): User?
 
-    suspend fun findByCredentialKakaoSubAndActiveTrue(fbId: String): User?
+    suspend fun findByCredentialKakaoSubAndActiveTrue(kakaoSub: String): User?
+
+    suspend fun findByCredentialAppleSubAndActiveTrue(appleSub: String): User?
 
     suspend fun findByNicknameAndActiveTrue(nickname: String): User?
 

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -39,4 +39,6 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
     suspend fun existsByCredentialKakaoSubAndActiveTrue(kakaoSub: String): Boolean
 
     fun findAllByNicknameStartingWith(nickname: String): Flow<User>
+
+    suspend fun findByCredentialAppleTransferSubAndActiveTrue(appleTransferSub: String): User?
 }

--- a/core/src/main/kotlin/users/service/AuthService.kt
+++ b/core/src/main/kotlin/users/service/AuthService.kt
@@ -40,6 +40,8 @@ interface AuthService {
 
     fun buildKakaoCredential(oAuth2UserResponse: OAuth2UserResponse): Credential
 
+    fun buildAppleCredential(oAuth2UserResponse: OAuth2UserResponse): Credential
+
     suspend fun socialLoginWithAccessToken(
         authProvider: AuthProvider,
         token: String,
@@ -105,6 +107,13 @@ class AuthServiceImpl(
         Credential(
             kakaoSub = oAuth2UserResponse.socialId,
             kakaoEmail = oAuth2UserResponse.email,
+        )
+
+    override fun buildAppleCredential(oAuth2UserResponse: OAuth2UserResponse) =
+        Credential(
+            appleSub = oAuth2UserResponse.socialId,
+            appleEmail = oAuth2UserResponse.email,
+            appleTransferSub = oAuth2UserResponse.transferInfo,
         )
 
     private fun hmacSHA256Hex(data: String): String {

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -445,8 +445,8 @@ class UserServiceImpl(
         val oauth2UserResponse = authService.socialLoginWithAccessToken(authProvider, token)
         if (oauth2UserResponse.email != null) {
             val presentUser = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)
-            if (presentUser?.id != user.id) {
-                throw DuplicateEmailException(getAttachedAuthProviders(user))
+            if (presentUser != null && presentUser.id != user.id) {
+                throw DuplicateEmailException(getAttachedAuthProviders(presentUser))
             }
         }
 


### PR DESCRIPTION
- 애플 로그인에는 transfer_sub를 이용하여 애플 사용자 정보를 수정하는 로직이 있어 `OAuth2UserResponse`에 `transferInfo` 필드를 추가했습니다.
- 레거시 코드에는 `AppleUserInfo`에 애플의 jwt 클레임에 있는 모든 필드가 다 있는데, 마이그레이션하면서 필요한 필드만 포함하였습니다.
- jwt 관련해서는 api 모듈에만 있던 `io.jsonwebtoken:jjwt:0.9.1`를 코어 모듈에도 추가해서 구현했고, jwk를 rsa공개키로 바꾸는 것은 빌트인 패키지인 `java.security`를 이용했습니다.
- 아직 테스트 안 해서 테스트해보고 변경사항이 있을 수도 있습니다.