### PR TITLE
구버전에서 비번 찾기 요청하는 경우 오류 응답

### DIFF
--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -52,6 +52,7 @@ enum class ErrorType(
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, 40018, "인증 코드가 유효하지 않습니다.", "인증 코드가 유효하지 않습니다."),
     ALREADY_LOCAL_ACCOUNT(HttpStatus.BAD_REQUEST, 40019, "이미 로컬 계정이 존재합니다.", "이미 로컬 계정이 존재합니다."),
     ALREADY_SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, 40020, "이미 소셜 계정이 존재합니다.", "이미 소셜 계정이 존재합니다."),
+    UPDATE_APP_VERSION(HttpStatus.BAD_REQUEST, 40021, "앱 버전을 업데이트해주세요.", "앱 버전을 업데이트해주세요."),
 
     SOCIAL_CONNECT_FAIL(HttpStatus.UNAUTHORIZED, 40100, "소셜 로그인에 실패했습니다.", "소셜 로그인에 실패했습니다."),
 

--- a/core/src/main/kotlin/common/exception/Snu4tException.kt
+++ b/core/src/main/kotlin/common/exception/Snu4tException.kt
@@ -78,6 +78,8 @@ object AlreadyLocalAccountException : Snu4tException(ErrorType.ALREADY_LOCAL_ACC
 
 object AlreadySocialAccountException : Snu4tException(ErrorType.ALREADY_SOCIAL_ACCOUNT)
 
+object UpdateAppVersionException : Snu4tException(ErrorType.UPDATE_APP_VERSION)
+
 object SocialConnectFailException : Snu4tException(ErrorType.SOCIAL_CONNECT_FAIL)
 
 object NoUserFcmKeyException : Snu4tException(ErrorType.NO_USER_FCM_KEY)

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -19,6 +19,7 @@ import com.wafflestudio.snu4t.common.exception.InvalidVerificationCodeException
 import com.wafflestudio.snu4t.common.exception.Snu4tException
 import com.wafflestudio.snu4t.common.exception.SocialProviderNotAttachedException
 import com.wafflestudio.snu4t.common.exception.TooManyVerificationCodeRequestException
+import com.wafflestudio.snu4t.common.exception.UpdateAppVersionException
 import com.wafflestudio.snu4t.common.exception.UserNotFoundException
 import com.wafflestudio.snu4t.common.exception.WrongLocalIdException
 import com.wafflestudio.snu4t.common.exception.WrongPasswordException
@@ -508,6 +509,7 @@ class UserServiceImpl(
     }
 
     override suspend fun sendResetPasswordCode(email: String) {
+        if (email.replace(emailMaskRegex, "*") == email) throw UpdateAppVersionException
         val user = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email) ?: throw UserNotFoundException
         val key = RESET_PASSWORD_CODE_PREFIX + user.id
         val code = Base64.getUrlEncoder().encodeToString(Random.nextBytes(6))


### PR DESCRIPTION
비밀번호 찾기 스펙이 바뀌면서 클라에서 서버가 오류 메시지를 띄워주면 좋겠다고 해서 이메일 마스킹한 것과 같은 형식으로 요청이 오면 앱 버전 올리라는 오류 띄우게 만들었습니다
버전으로 분기하는게 별로라고 해서 이렇게 해봤는데 이게 최선인지는 잘 모르겠네요