### PR TITLE
findLastChild regex에 exact match 적용

### DIFF
--- a/core/src/main/kotlin/theme/repository/TimetableThemeCustomRepository.kt
+++ b/core/src/main/kotlin/theme/repository/TimetableThemeCustomRepository.kt
@@ -45,7 +45,7 @@ class TimetableThemeCustomRepositoryImpl(
         return reactiveMongoTemplate.findOne(
             Query.query(
                 TimetableTheme::userId isEqualTo userId and
-                    TimetableTheme::name regex """${Regex.escape(name)}(\s+\(\d+\))?""",
+                    TimetableTheme::name regex """^${Regex.escape(name)}(\s+\(\d+\))?$""",
             ).with(TimetableTheme::name.desc()),
             TimetableTheme::class.java,
         ).awaitSingleOrNull()


### PR DESCRIPTION
커스텀테마 마지막 번호 찾는 부분인데 의도한 부분인지는 모르겠지만 시작과 끝을 매칭 안하고 있어서 앞에 다른 문자열이 와도 검색에 포함하는 문제가 있었습니다
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1731770542089069