### PR TITLE
비밀번호 재설정 인증코드 시간 연장 오류 수정

### DIFF
--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -569,7 +569,7 @@ class UserServiceImpl(
         val user = userRepository.findByCredentialLocalIdAndActiveTrue(localId) ?: throw UserNotFoundException
         val key = RESET_PASSWORD_CODE_PREFIX + user.id
         checkVerificationValue(key, code)
-        redisTemplate.opsForValue().getAndExpire(key, Duration.ofMinutes(3)).subscribe()
+        redisTemplate.expire(key, Duration.ofMinutes(3)).subscribe()
     }
 
     override suspend fun getMaskedEmail(localId: String): String {


### PR DESCRIPTION
getAndExpire를 안 써도 되고 이 명령 자체가 현재 redis 버전에서 지원이 안되네요
기능에 좀 큰 문제라 일단 머지하겠습니다