### PR TITLE
ev-service 마이그레이션

### DIFF
--- a/api/src/main/kotlin/filter/ErrorWebFilter.kt
+++ b/api/src/main/kotlin/filter/ErrorWebFilter.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.snu4t.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.wafflestudio.snu4t.common.exception.ErrorType
-import com.wafflestudio.snu4t.common.exception.ProxyException
+import com.wafflestudio.snu4t.common.exception.EvServiceProxyException
 import com.wafflestudio.snu4t.common.exception.Snu4tException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -27,52 +27,40 @@ class ErrorWebFilter(
     ): Mono<Void> {
         return chain.filter(exchange)
             .onErrorResume { throwable ->
-                if (throwable is ProxyException) {
-                    exchange.response.statusCode = throwable.statusCode
-                    exchange.response.headers.contentType = MediaType.APPLICATION_JSON
-                    exchange.response.writeWith(
-                        Mono.just(
-                            exchange.response
-                                .bufferFactory()
-                                .wrap(objectMapper.writeValueAsBytes(throwable.errorBody)),
-                        ),
-                    )
-                } else {
-                    val errorBody: ErrorBody
-                    val httpStatusCode: HttpStatusCode
-                    when (throwable) {
-                        is Snu4tException -> {
-                            httpStatusCode = throwable.error.httpStatus
-                            errorBody = makeErrorBody(throwable)
-                        }
-
-                        is ResponseStatusException -> {
-                            httpStatusCode = throwable.statusCode
-                            errorBody =
-                                makeErrorBody(
-                                    Snu4tException(
-                                        errorMessage = throwable.body.title ?: ErrorType.DEFAULT_ERROR.errorMessage,
-                                    ),
-                                )
-                        }
-
-                        else -> {
-                            log.error(throwable.message, throwable)
-                            httpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR
-                            errorBody = makeErrorBody(Snu4tException())
-                        }
+                val errorBody: Any
+                val httpStatusCode: HttpStatusCode
+                when (throwable) {
+                    is EvServiceProxyException -> {
+                        httpStatusCode = throwable.statusCode
+                        errorBody = throwable.errorBody
                     }
-
-                    exchange.response.statusCode = httpStatusCode
-                    exchange.response.headers.contentType = MediaType.APPLICATION_JSON
-                    exchange.response.writeWith(
-                        Mono.just(
-                            exchange.response
-                                .bufferFactory()
-                                .wrap(objectMapper.writeValueAsBytes(errorBody)),
-                        ),
-                    )
+                    is Snu4tException -> {
+                        httpStatusCode = throwable.error.httpStatus
+                        errorBody = makeErrorBody(throwable)
+                    }
+                    is ResponseStatusException -> {
+                        httpStatusCode = throwable.statusCode
+                        errorBody =
+                            makeErrorBody(
+                                Snu4tException(errorMessage = throwable.body.title ?: ErrorType.DEFAULT_ERROR.errorMessage),
+                            )
+                    }
+                    else -> {
+                        log.error(throwable.message, throwable)
+                        httpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR
+                        errorBody = makeErrorBody(Snu4tException())
+                    }
                 }
+
+                exchange.response.statusCode = httpStatusCode
+                exchange.response.headers.contentType = MediaType.APPLICATION_JSON
+                exchange.response.writeWith(
+                    Mono.just(
+                        exchange.response
+                            .bufferFactory()
+                            .wrap(objectMapper.writeValueAsBytes(errorBody)),
+                    ),
+                )
             }
     }
 

--- a/api/src/main/kotlin/handler/EvServiceHandler.kt
+++ b/api/src/main/kotlin/handler/EvServiceHandler.kt
@@ -1,83 +1,39 @@
 package com.wafflestudio.snu4t.handler
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.wafflestudio.snu4t.config.SnuttEvWebClient
-import com.wafflestudio.snu4t.coursebook.service.CoursebookService
-import com.wafflestudio.snu4t.evaluation.dto.EvLectureInfoDto
+import com.wafflestudio.snu4t.evaluation.service.EvService
 import com.wafflestudio.snu4t.middleware.SnuttRestApiDefaultMiddleware
-import com.wafflestudio.snu4t.timetables.service.TimetableService
-import kotlinx.coroutines.flow.toList
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.BodyInserters
-import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.awaitBody
-import org.springframework.web.util.UriComponentsBuilder
-import java.net.URLEncoder
 
 @Component
 class EvServiceHandler(
-    private val coursebookService: CoursebookService,
-    private val timetableService: TimetableService,
-    private val snuttEvWebClient: SnuttEvWebClient,
+    private val evService: EvService,
     snuttRestApiDefaultMiddleware: SnuttRestApiDefaultMiddleware,
 ) : ServiceHandler(snuttRestApiDefaultMiddleware) {
-    suspend fun handleGet(req: ServerRequest) = handleRouting(req, HttpMethod.GET)
+    suspend fun handleGet(req: ServerRequest) =
+        handle(req) {
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.GET)
+        }
 
-    suspend fun handlePost(req: ServerRequest) = handleRouting(req, HttpMethod.POST)
+    suspend fun handlePost(req: ServerRequest) =
+        handle(req) {
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.POST)
+        }
 
-    suspend fun handleDelete(req: ServerRequest) = handleRouting(req, HttpMethod.DELETE)
+    suspend fun handleDelete(req: ServerRequest) =
+        handle(req) {
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.DELETE)
+        }
 
-    suspend fun handlePatch(req: ServerRequest) = handleRouting(req, HttpMethod.PATCH)
-
-    private suspend fun handleRouting(
-        req: ServerRequest,
-        method: HttpMethod,
-    ) = handle(req) {
-        val userId = req.userId
-        val requestPath = req.pathVariable("requestPath")
-        val originalBody = req.awaitBody<String>()
-
-        snuttEvWebClient.method(method)
-            .uri { builder -> builder.path("/v1").path(requestPath).build() }
-            .header("Snutt-User-Id", userId)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(BodyInserters.fromValue(originalBody))
-            .retrieve()
-            .awaitBody()
-    }
+    suspend fun handlePatch(req: ServerRequest) =
+        handle(req) {
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.PATCH)
+        }
 
     suspend fun getMyLatestLectures(req: ServerRequest) =
         handle(req) {
-            val userId = req.userId
-            val requestQueryParams = req.queryParams()
-            val recentLectures =
-                coursebookService.getLastTwoCourseBooks().flatMap { coursebook ->
-                    timetableService.getTimetablesBySemester(userId, coursebook.year, coursebook.semester)
-                        .toList()
-                        .flatMap {
-                                timetable ->
-                            timetable.lectures.map { lecture -> EvLectureInfoDto(lecture, coursebook.year, coursebook.semester) }
-                        }
-                }
-            val recentLecturesJson = ObjectMapper().writeValueAsString(recentLectures).filterNot { it.isWhitespace() }
-            val encodedJson = URLEncoder.encode(recentLecturesJson, "EUC-KR")
-
-            snuttEvWebClient.get()
-                .uri { builder ->
-                    UriComponentsBuilder.fromUri(builder.build())
-                        .path("/v1/users/me/lectures/latest")
-                        .queryParam("snutt_lecture_info", encodedJson)
-                        .queryParams(requestQueryParams)
-                        .build(true).toUri()
-                }
-                .header("Snutt-User-Id", userId)
-                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .retrieve()
-                .awaitBody()
+            evService.getMyLatestLectures(req.userId, req.queryParams())
         }
 }

--- a/api/src/main/kotlin/handler/EvServiceHandler.kt
+++ b/api/src/main/kotlin/handler/EvServiceHandler.kt
@@ -1,7 +1,13 @@
 package com.wafflestudio.snu4t.handler
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wafflestudio.snu4t.common.enum.Semester
 import com.wafflestudio.snu4t.config.SnuttEvWebClient
+import com.wafflestudio.snu4t.coursebook.service.CoursebookService
 import com.wafflestudio.snu4t.middleware.SnuttRestApiDefaultMiddleware
+import com.wafflestudio.snu4t.timetables.data.TimetableLecture
+import com.wafflestudio.snu4t.timetables.service.TimetableService
+import kotlinx.coroutines.flow.toList
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
@@ -10,9 +16,13 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.awaitBody
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLEncoder
 
 @Component
 class EvServiceHandler(
+    private val coursebookService: CoursebookService,
+    private val timetableService: TimetableService,
     private val snuttEvWebClient: SnuttEvWebClient,
     snuttRestApiDefaultMiddleware: SnuttRestApiDefaultMiddleware,
 ) : ServiceHandler(snuttRestApiDefaultMiddleware) {
@@ -24,7 +34,7 @@ class EvServiceHandler(
 
     suspend fun handlePatch(req: ServerRequest) = handleRouting(req, HttpMethod.PATCH)
 
-    suspend fun handleRouting(
+    private suspend fun handleRouting(
         req: ServerRequest,
         method: HttpMethod,
     ) = handle(req) {
@@ -40,4 +50,54 @@ class EvServiceHandler(
             .retrieve()
             .awaitBody()
     }
+
+    suspend fun getMyLatestLectures(req: ServerRequest) =
+        handle(req) {
+            val userId = req.userId
+            val requestQueryParams = req.queryParams()
+            val recentLectures =
+                coursebookService.getLastTwoCourseBooks().flatMap { coursebook ->
+                    timetableService.getTimetablesBySemester(userId, coursebook.year, coursebook.semester)
+                        .toList()
+                        .flatMap {
+                                timetable ->
+                            timetable.lectures.map { lecture -> EvLectureDto(lecture, coursebook.year, coursebook.semester) }
+                        }
+                }
+            val recentLecturesJson = ObjectMapper().writeValueAsString(recentLectures).filterNot { it.isWhitespace() }
+            val encodedJson = URLEncoder.encode(recentLecturesJson, "EUC-KR")
+
+            snuttEvWebClient.get()
+                .uri { builder ->
+                    UriComponentsBuilder.fromUri(builder.build())
+                        .path("/v1/users/me/lectures/latest")
+                        .queryParam("snutt_lecture_info", encodedJson)
+                        .queryParams(requestQueryParams)
+                        .build(true).toUri()
+                }
+                .header("Snutt-User-Id", userId)
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .retrieve()
+                .awaitBody()
+        }
 }
+
+data class EvLectureDto(
+    val year: Int,
+    val semester: Int,
+    val instructor: String?,
+    val courseNumber: String?,
+)
+
+fun EvLectureDto(
+    timetableLecture: TimetableLecture,
+    year: Int,
+    semester: Semester,
+): EvLectureDto =
+    EvLectureDto(
+        year = year,
+        semester = semester.value,
+        instructor = timetableLecture.instructor,
+        courseNumber = timetableLecture.courseNumber,
+    )

--- a/api/src/main/kotlin/handler/EvServiceHandler.kt
+++ b/api/src/main/kotlin/handler/EvServiceHandler.kt
@@ -1,0 +1,43 @@
+package com.wafflestudio.snu4t.handler
+
+import com.wafflestudio.snu4t.config.SnuttEvWebClient
+import com.wafflestudio.snu4t.middleware.SnuttRestApiDefaultMiddleware
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.awaitBody
+
+@Component
+class EvServiceHandler(
+    private val snuttEvWebClient: SnuttEvWebClient,
+    snuttRestApiDefaultMiddleware: SnuttRestApiDefaultMiddleware,
+) : ServiceHandler(snuttRestApiDefaultMiddleware) {
+    suspend fun handleGet(req: ServerRequest) = handleRouting(req, HttpMethod.GET)
+
+    suspend fun handlePost(req: ServerRequest) = handleRouting(req, HttpMethod.POST)
+
+    suspend fun handleDelete(req: ServerRequest) = handleRouting(req, HttpMethod.DELETE)
+
+    suspend fun handlePatch(req: ServerRequest) = handleRouting(req, HttpMethod.PATCH)
+
+    suspend fun handleRouting(
+        req: ServerRequest,
+        method: HttpMethod,
+    ) = handle(req) {
+        val userId = req.userId
+        val requestPath = req.pathVariable("requestPath")
+        val originalBody = req.awaitBody<String>()
+
+        snuttEvWebClient.method(method)
+            .uri { builder -> builder.path("/v1").path(requestPath).build() }
+            .header("Snutt-User-Id", userId)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(BodyInserters.fromValue(originalBody))
+            .retrieve()
+            .awaitBody()
+    }
+}

--- a/api/src/main/kotlin/handler/EvServiceHandler.kt
+++ b/api/src/main/kotlin/handler/EvServiceHandler.kt
@@ -2,10 +2,11 @@ package com.wafflestudio.snu4t.handler
 
 import com.wafflestudio.snu4t.evaluation.service.EvService
 import com.wafflestudio.snu4t.middleware.SnuttRestApiDefaultMiddleware
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.awaitBody
+import org.springframework.web.reactive.function.server.bodyToMono
 
 @Component
 class EvServiceHandler(
@@ -14,22 +15,26 @@ class EvServiceHandler(
 ) : ServiceHandler(snuttRestApiDefaultMiddleware) {
     suspend fun handleGet(req: ServerRequest) =
         handle(req) {
-            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.GET)
+            val body = req.bodyToMono<String>().awaitSingleOrNull() ?: ""
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), body, HttpMethod.GET)
         }
 
     suspend fun handlePost(req: ServerRequest) =
         handle(req) {
-            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.POST)
+            val body = req.bodyToMono<String>().awaitSingleOrNull() ?: ""
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), body, HttpMethod.POST)
         }
 
     suspend fun handleDelete(req: ServerRequest) =
         handle(req) {
-            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.DELETE)
+            val body = req.bodyToMono<String>().awaitSingleOrNull() ?: ""
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), body, HttpMethod.DELETE)
         }
 
     suspend fun handlePatch(req: ServerRequest) =
         handle(req) {
-            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), req.awaitBody(), HttpMethod.PATCH)
+            val body = req.bodyToMono<String>().awaitSingleOrNull() ?: ""
+            evService.handleRouting(req.userId, req.pathVariable("requestPath"), req.queryParams(), body, HttpMethod.PATCH)
         }
 
     suspend fun getMyLatestLectures(req: ServerRequest) =

--- a/api/src/main/kotlin/handler/EvServiceHandler.kt
+++ b/api/src/main/kotlin/handler/EvServiceHandler.kt
@@ -1,11 +1,10 @@
 package com.wafflestudio.snu4t.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.wafflestudio.snu4t.common.enum.Semester
 import com.wafflestudio.snu4t.config.SnuttEvWebClient
 import com.wafflestudio.snu4t.coursebook.service.CoursebookService
+import com.wafflestudio.snu4t.evaluation.dto.EvLectureInfoDto
 import com.wafflestudio.snu4t.middleware.SnuttRestApiDefaultMiddleware
-import com.wafflestudio.snu4t.timetables.data.TimetableLecture
 import com.wafflestudio.snu4t.timetables.service.TimetableService
 import kotlinx.coroutines.flow.toList
 import org.springframework.http.HttpHeaders
@@ -61,7 +60,7 @@ class EvServiceHandler(
                         .toList()
                         .flatMap {
                                 timetable ->
-                            timetable.lectures.map { lecture -> EvLectureDto(lecture, coursebook.year, coursebook.semester) }
+                            timetable.lectures.map { lecture -> EvLectureInfoDto(lecture, coursebook.year, coursebook.semester) }
                         }
                 }
             val recentLecturesJson = ObjectMapper().writeValueAsString(recentLectures).filterNot { it.isWhitespace() }
@@ -82,22 +81,3 @@ class EvServiceHandler(
                 .awaitBody()
         }
 }
-
-data class EvLectureDto(
-    val year: Int,
-    val semester: Int,
-    val instructor: String?,
-    val courseNumber: String?,
-)
-
-fun EvLectureDto(
-    timetableLecture: TimetableLecture,
-    year: Int,
-    semester: Semester,
-): EvLectureDto =
-    EvLectureDto(
-        year = year,
-        semester = semester.value,
-        instructor = timetableLecture.instructor,
-        courseNumber = timetableLecture.courseNumber,
-    )

--- a/api/src/main/kotlin/router/MainRouter.kt
+++ b/api/src/main/kotlin/router/MainRouter.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.snu4t.handler.ConfigHandler
 import com.wafflestudio.snu4t.handler.CoursebookHandler
 import com.wafflestudio.snu4t.handler.DeviceHandler
 import com.wafflestudio.snu4t.handler.EvHandler
+import com.wafflestudio.snu4t.handler.EvServiceHandler
 import com.wafflestudio.snu4t.handler.FeedbackHandler
 import com.wafflestudio.snu4t.handler.FriendHandler
 import com.wafflestudio.snu4t.handler.FriendTableHandler
@@ -68,6 +69,7 @@ class MainRouter(
     private val tagHandler: TagHandler,
     private val feedbackHandler: FeedbackHandler,
     private val staticPageHandler: StaticPageHandler,
+    private val evServiceHandler: EvServiceHandler,
 ) {
     @Bean
     fun healthCheck() =
@@ -293,6 +295,15 @@ class MainRouter(
     fun evRouter() =
         v1CoRouter {
             GET("/ev/lectures/{lectureId}/summary", evHandler::getLectureEvaluationSummary)
+        }
+
+    @Bean
+    fun evServiceRouter() =
+        v1CoRouter {
+            GET("/ev-service/{*requestPath}", evServiceHandler::handleGet)
+            POST("/ev-service/{*requestPath}", evServiceHandler::handlePost)
+            DELETE("/ev-service/{*requestPath}", evServiceHandler::handleDelete)
+            PATCH("/ev-service/{*requestPath}", evServiceHandler::handlePatch)
         }
 
     @Bean

--- a/api/src/main/kotlin/router/MainRouter.kt
+++ b/api/src/main/kotlin/router/MainRouter.kt
@@ -300,6 +300,7 @@ class MainRouter(
     @Bean
     fun evServiceRouter() =
         v1CoRouter {
+            GET("/ev-service/v1/users/me/lectures/latest", evServiceHandler::getMyLatestLectures)
             GET("/ev-service/{*requestPath}", evServiceHandler::handleGet)
             POST("/ev-service/{*requestPath}", evServiceHandler::handlePost)
             DELETE("/ev-service/{*requestPath}", evServiceHandler::handleDelete)

--- a/api/src/test/kotlin/timetable/TimetableIntegTest.kt
+++ b/api/src/test/kotlin/timetable/TimetableIntegTest.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snu4t.timetable
 import BaseIntegTest
 import com.ninjasquad.springmockk.MockkBean
 import com.wafflestudio.snu4t.evaluation.repository.SnuttEvRepository
+import com.wafflestudio.snu4t.evaluation.service.EvService
 import com.wafflestudio.snu4t.fixture.TimetableFixture
 import com.wafflestudio.snu4t.fixture.UserFixture
 import com.wafflestudio.snu4t.handler.RequestContext
@@ -25,6 +26,7 @@ import timetables.dto.TimetableBriefDto
 class TimetableIntegTest(
     @MockkBean private val mockMiddleware: SnuttRestApiDefaultMiddleware,
     @MockkBean private val mockSnuttEvRepository: SnuttEvRepository,
+    @MockkBean private val evService: EvService,
     val mainRouter: MainRouter,
     val timetableFixture: TimetableFixture,
     val userFixture: UserFixture,

--- a/core/src/main/kotlin/common/exception/EvServiceProxyException.kt
+++ b/core/src/main/kotlin/common/exception/EvServiceProxyException.kt
@@ -1,9 +1,8 @@
 package com.wafflestudio.snu4t.common.exception
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.http.HttpStatusCode
 
-class ProxyException(
+class EvServiceProxyException(
     val statusCode: HttpStatusCode,
     val errorBody: Map<String, Any?>,
-) : RuntimeException(ObjectMapper().writeValueAsString(errorBody))
+) : RuntimeException()

--- a/core/src/main/kotlin/common/exception/ProxyException.kt
+++ b/core/src/main/kotlin/common/exception/ProxyException.kt
@@ -1,8 +1,9 @@
 package com.wafflestudio.snu4t.common.exception
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.http.HttpStatusCode
 
 class ProxyException(
     val statusCode: HttpStatusCode,
     val errorBody: Map<String, Any?>,
-) : RuntimeException(errorBody.toString())
+) : RuntimeException(ObjectMapper().writeValueAsString(errorBody))

--- a/core/src/main/kotlin/common/exception/ProxyException.kt
+++ b/core/src/main/kotlin/common/exception/ProxyException.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.snu4t.common.exception
+
+import org.springframework.http.HttpStatusCode
+
+class ProxyException(
+    val statusCode: HttpStatusCode,
+    val errorBody: Map<String, Any?>,
+) : RuntimeException(errorBody.toString())

--- a/core/src/main/kotlin/coursebook/repository/CoursebookRepository.kt
+++ b/core/src/main/kotlin/coursebook/repository/CoursebookRepository.kt
@@ -9,4 +9,6 @@ interface CoursebookRepository : CoroutineCrudRepository<Coursebook, String> {
     suspend fun findFirstByOrderByYearDescSemesterDesc(): Coursebook
 
     suspend fun findAllByOrderByYearDescSemesterDesc(): List<Coursebook>
+
+    suspend fun findTop2ByOrderByYearDescSemesterDesc(): List<Coursebook>
 }

--- a/core/src/main/kotlin/coursebook/repository/CoursebookRepository.kt
+++ b/core/src/main/kotlin/coursebook/repository/CoursebookRepository.kt
@@ -10,5 +10,5 @@ interface CoursebookRepository : CoroutineCrudRepository<Coursebook, String> {
 
     suspend fun findAllByOrderByYearDescSemesterDesc(): List<Coursebook>
 
-    suspend fun findTop2ByOrderByYearDescSemesterDesc(): List<Coursebook>
+    suspend fun findTop3ByOrderByYearDescSemesterDesc(): List<Coursebook>
 }

--- a/core/src/main/kotlin/coursebook/service/CoursebookService.kt
+++ b/core/src/main/kotlin/coursebook/service/CoursebookService.kt
@@ -9,7 +9,7 @@ interface CoursebookService {
 
     suspend fun getCoursebooks(): List<Coursebook>
 
-    suspend fun getLastTwoCourseBooks(): List<Coursebook>
+    suspend fun getLastTwoCourseBooksBeforeCurrent(): List<Coursebook>
 }
 
 @Service
@@ -18,5 +18,8 @@ class CoursebookServiceImpl(private val coursebookRepository: CoursebookReposito
 
     override suspend fun getCoursebooks(): List<Coursebook> = coursebookRepository.findAllByOrderByYearDescSemesterDesc()
 
-    override suspend fun getLastTwoCourseBooks(): List<Coursebook> = coursebookRepository.findTop2ByOrderByYearDescSemesterDesc()
+    override suspend fun getLastTwoCourseBooksBeforeCurrent(): List<Coursebook> =
+        coursebookRepository.findTop3ByOrderByYearDescSemesterDesc().slice(
+            1..2,
+        )
 }

--- a/core/src/main/kotlin/coursebook/service/CoursebookService.kt
+++ b/core/src/main/kotlin/coursebook/service/CoursebookService.kt
@@ -8,6 +8,8 @@ interface CoursebookService {
     suspend fun getLatestCoursebook(): Coursebook
 
     suspend fun getCoursebooks(): List<Coursebook>
+
+    suspend fun getLastTwoCourseBooks(): List<Coursebook>
 }
 
 @Service
@@ -15,4 +17,6 @@ class CoursebookServiceImpl(private val coursebookRepository: CoursebookReposito
     override suspend fun getLatestCoursebook(): Coursebook = coursebookRepository.findFirstByOrderByYearDescSemesterDesc()
 
     override suspend fun getCoursebooks(): List<Coursebook> = coursebookRepository.findAllByOrderByYearDescSemesterDesc()
+
+    override suspend fun getLastTwoCourseBooks(): List<Coursebook> = coursebookRepository.findTop2ByOrderByYearDescSemesterDesc()
 }

--- a/core/src/main/kotlin/evaluation/dto/EvLectureInfoDto.kt
+++ b/core/src/main/kotlin/evaluation/dto/EvLectureInfoDto.kt
@@ -1,0 +1,23 @@
+package com.wafflestudio.snu4t.evaluation.dto
+
+import com.wafflestudio.snu4t.common.enum.Semester
+import com.wafflestudio.snu4t.timetables.data.TimetableLecture
+
+data class EvLectureInfoDto(
+    val year: Int,
+    val semester: Int,
+    val instructor: String?,
+    val courseNumber: String?,
+)
+
+fun EvLectureInfoDto(
+    timetableLecture: TimetableLecture,
+    year: Int,
+    semester: Semester,
+): EvLectureInfoDto =
+    EvLectureInfoDto(
+        year = year,
+        semester = semester.value,
+        instructor = timetableLecture.instructor,
+        courseNumber = timetableLecture.courseNumber,
+    )

--- a/core/src/main/kotlin/evaluation/dto/EvLectureInfoDto.kt
+++ b/core/src/main/kotlin/evaluation/dto/EvLectureInfoDto.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snu4t.evaluation.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snu4t.common.enum.Semester
 import com.wafflestudio.snu4t.timetables.data.TimetableLecture
 
@@ -7,6 +8,7 @@ data class EvLectureInfoDto(
     val year: Int,
     val semester: Int,
     val instructor: String?,
+    @JsonProperty("course_number")
     val courseNumber: String?,
 )
 

--- a/core/src/main/kotlin/evaluation/dto/EvUserDto.kt
+++ b/core/src/main/kotlin/evaluation/dto/EvUserDto.kt
@@ -1,16 +1,18 @@
 package com.wafflestudio.snu4t.evaluation.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snu4t.users.data.User
 
 data class EvUserDto(
     val id: String?,
     val email: String?,
-    val local_id: String?,
+    @JsonProperty("local_id")
+    val localId: String?,
 )
 
 fun EvUserDto(user: User) =
     EvUserDto(
         id = user.id,
         email = user.email,
-        local_id = user.credential.localId,
+        localId = user.credential.localId,
     )

--- a/core/src/main/kotlin/evaluation/dto/EvUserDto.kt
+++ b/core/src/main/kotlin/evaluation/dto/EvUserDto.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.snu4t.evaluation.dto
+
+import com.wafflestudio.snu4t.users.data.User
+
+data class EvUserDto(
+    val id: String?,
+    val email: String?,
+    val local_id: String?,
+)
+
+fun EvUserDto(user: User) =
+    EvUserDto(
+        id = user.id,
+        email = user.email,
+        local_id = user.credential.localId,
+    )

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -1,0 +1,88 @@
+package com.wafflestudio.snu4t.evaluation.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.wafflestudio.snu4t.common.util.buildMultiValueMap
+import com.wafflestudio.snu4t.config.SnuttEvWebClient
+import com.wafflestudio.snu4t.coursebook.service.CoursebookService
+import com.wafflestudio.snu4t.evaluation.dto.EvLectureInfoDto
+import com.wafflestudio.snu4t.timetables.service.TimetableService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.util.MultiValueMap
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLEncoder
+
+@Service
+class EvService(
+    @Qualifier("snuttevServer")
+    private val snuttEvWebClient: SnuttEvWebClient,
+    private val timetableService: TimetableService,
+    private val coursebookService: CoursebookService,
+) {
+    suspend fun handleRouting(
+        userId: String,
+        requestPath: String,
+        requestQueryParams: MultiValueMap<String, String> = buildMultiValueMap(mapOf()),
+        originalBody: String,
+        method: HttpMethod,
+    ): Map<String, Any> =
+        snuttEvWebClient.method(method)
+            .uri { builder -> builder.path("/v1").path(requestPath).queryParams(requestQueryParams).build() }
+            .header("Snutt-User-Id", userId)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(BodyInserters.fromValue(originalBody))
+            .retrieve()
+            .awaitBody()
+
+    suspend fun getMyLatestLectures(
+        userId: String,
+        requestQueryParams: MultiValueMap<String, String>? = null,
+    ): Map<String, Any> {
+        val recentLectures: List<EvLectureInfoDto> =
+            coursebookService.getLastTwoCourseBooksBeforeCurrent().flatMap { coursebook ->
+                timetableService.getTimetablesBySemester(userId, coursebook.year, coursebook.semester)
+                    .toList()
+                    .flatMap { timetable ->
+                        timetable.lectures.map { lecture ->
+                            EvLectureInfoDto(
+                                lecture,
+                                coursebook.year,
+                                coursebook.semester,
+                            )
+                        }
+                    }
+            }
+
+        val recentLecturesJson =
+            ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .writeValueAsString(recentLectures)
+        val encodedJson =
+            withContext(Dispatchers.IO) {
+                URLEncoder.encode(recentLecturesJson, "UTF-8")
+            }
+
+        return snuttEvWebClient.get()
+            .uri { builder ->
+                UriComponentsBuilder.fromUri(builder.build())
+                    .path("/v1/users/me/lectures/latest")
+                    .queryParam("snutt_lecture_info", encodedJson)
+                    .queryParams(requestQueryParams)
+                    .build(true).toUri()
+            }
+            .header("Snutt-User-Id", userId)
+            .header(HttpHeaders.CONTENT_ENCODING, "UTF-8")
+            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .retrieve()
+            .awaitBody()
+    }
+}

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.snu4t.evaluation.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.wafflestudio.snu4t.common.exception.ProxyException
+import com.wafflestudio.snu4t.common.exception.EvServiceProxyException
 import com.wafflestudio.snu4t.common.util.buildMultiValueMap
 import com.wafflestudio.snu4t.config.SnuttEvWebClient
 import com.wafflestudio.snu4t.coursebook.service.CoursebookService
@@ -51,7 +51,7 @@ class EvService(
                 .onStatus(HttpStatusCode::isError) { response ->
                     response.bodyToMono<Map<String, Any?>>()
                         .flatMap { errorBody ->
-                            Mono.error(ProxyException(response.statusCode(), errorBody))
+                            Mono.error(EvServiceProxyException(response.statusCode(), errorBody))
                         }
                 }
                 .bodyToMono<MutableMap<String, Any?>>()
@@ -101,7 +101,7 @@ class EvService(
             .onStatus(HttpStatusCode::isError) { response ->
                 response.bodyToMono<Map<String, Any?>>()
                     .flatMap { errorBody ->
-                        Mono.error(ProxyException(response.statusCode(), errorBody))
+                        Mono.error(EvServiceProxyException(response.statusCode(), errorBody))
                     }
             }
             .bodyToMono<MutableMap<String, Any?>>()

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -100,6 +100,7 @@ class EvService(
             .awaitSingle()
     }
 
+    @Suppress("UNCHECKED_CAST")
     private suspend fun updateUserInfo(data: MutableMap<String, Any?>): MutableMap<String, Any?> {
         val updatedMap: MutableMap<String, Any?> = mutableMapOf()
         for ((k, v) in data.entries) {

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -44,6 +44,8 @@ class EvService(
             snuttEvWebClient.method(method)
                 .uri { builder -> builder.path(requestPath).queryParams(requestQueryParams).build() }
                 .header("Snutt-User-Id", userId)
+                .header(HttpHeaders.CONTENT_ENCODING, "UTF-8")
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .body(BodyInserters.fromValue(originalBody))
                 .retrieve()

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -10,7 +10,6 @@ import com.wafflestudio.snu4t.timetables.service.TimetableService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
@@ -23,7 +22,6 @@ import java.net.URLEncoder
 
 @Service
 class EvService(
-    @Qualifier("snuttevServer")
     private val snuttEvWebClient: SnuttEvWebClient,
     private val timetableService: TimetableService,
     private val coursebookService: CoursebookService,

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -34,7 +34,7 @@ class EvService(
         method: HttpMethod,
     ): Map<String, Any> =
         snuttEvWebClient.method(method)
-            .uri { builder -> builder.path("/v1").path(requestPath).queryParams(requestQueryParams).build() }
+            .uri { builder -> builder.path(requestPath).queryParams(requestQueryParams).build() }
             .header("Snutt-User-Id", userId)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(BodyInserters.fromValue(originalBody))

--- a/core/src/main/kotlin/evaluation/service/EvService.kt
+++ b/core/src/main/kotlin/evaluation/service/EvService.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snu4t.evaluation.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.wafflestudio.snu4t.common.exception.EvServiceProxyException
 import com.wafflestudio.snu4t.common.util.buildMultiValueMap
 import com.wafflestudio.snu4t.config.SnuttEvWebClient
@@ -28,6 +27,7 @@ class EvService(
     private val timetableService: TimetableService,
     private val coursebookService: CoursebookService,
     private val userService: UserService,
+    private val objectMapper: ObjectMapper,
 ) {
     suspend fun handleRouting(
         userId: String,
@@ -74,10 +74,7 @@ class EvService(
                     }
             }
 
-        val lectureInfoParam =
-            ObjectMapper().setPropertyNamingStrategy(
-                PropertyNamingStrategies.SNAKE_CASE,
-            ).writeValueAsString(recentLectures)
+        val lectureInfoParam = objectMapper.writeValueAsString(recentLectures)
         return snuttEvWebClient.get()
             .uri { builder ->
                 builder


### PR DESCRIPTION
ev-service 프록시하는 부분을 기존에 쓰던 SnuttEvWebClient 사용해서 마이그레이션 진행했습니다

하면서 생긴 몇가지 문제가 있어서 공유드려요
1. req.method() 사용 불가: handler의 req에서 method()를 쓰면 에러가 나서 어쩔수 없이 http method마다 따로 함수를 만들어놨어요
2. SnuttEvWebClient read timeout 문제: 로컬에서 테스트할 때 SnuttEvWebClient의 read timeout을 초과할 때가 있고, 1.5초 정도로 늘리면 잘 되긴 하는데 올리는게 좋을까요?
3. `/v1/users/me/lectures/latest` 의 경우 query parameter에 json을 넣게 되어 있는데 이게 기본적으로는 스프링이 { 같은 특수문자를 변수 바꿔넣는 자리로 인식해서 이건  UriComponentsBuilder로 우회를 했어요

테스트 안돌아가서 다시 볼게요