### PR TITLE
Fix/apple login

### DIFF
--- a/api/src/main/kotlin/handler/AuthHandler.kt
+++ b/api/src/main/kotlin/handler/AuthHandler.kt
@@ -61,6 +61,12 @@ class AuthHandler(
             userService.loginKakao(socialLoginRequest)
         }
 
+    suspend fun loginAppleLegacy(req: ServerRequest): ServerResponse =
+        handle(req) {
+            val socialLoginRequest: SocialLoginRequest = req.awaitBodyOrNull() ?: throw ServerWebInputException("Invalid body")
+            userService.loginApple(socialLoginRequest)
+        }
+
     suspend fun loginApple(req: ServerRequest): ServerResponse =
         handle(req) {
             val socialLoginRequest: SocialLoginRequest = req.awaitBodyOrNull() ?: throw ServerWebInputException("Invalid body")

--- a/api/src/main/kotlin/router/MainRouter.kt
+++ b/api/src/main/kotlin/router/MainRouter.kt
@@ -86,6 +86,7 @@ class MainRouter(
                 POST("/login/facebook", authHandler::loginFacebook)
                 POST("/login/google", authHandler::loginGoogle)
                 POST("/login/kakao", authHandler::loginKakao)
+                POST("/login_apple", authHandler::loginAppleLegacy)
                 POST("/login/apple", authHandler::loginApple)
                 POST("/logout", authHandler::logout)
                 POST("/password/reset/email/check", authHandler::getMaskedEmail)

--- a/api/src/main/kotlin/router/docs/AuthDocs.kt
+++ b/api/src/main/kotlin/router/docs/AuthDocs.kt
@@ -168,30 +168,6 @@ import org.springframework.web.bind.annotation.RequestMethod
             ),
     ),
     RouterOperation(
-        path = "/v1/auth/login_apple",
-        method = [RequestMethod.POST],
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-        operation =
-            Operation(
-                operationId = "loginAppleLegacy",
-                requestBody =
-                    RequestBody(
-                        content = [
-                            Content(
-                                schema = Schema(implementation = SocialLoginRequest::class),
-                                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            ),
-                        ],
-                    ),
-                responses = [
-                    ApiResponse(
-                        responseCode = "200",
-                        content = [Content(schema = Schema(implementation = LoginResponse::class))],
-                    ),
-                ],
-            ),
-    ),
-    RouterOperation(
         path = "/v1/auth/login/apple",
         method = [RequestMethod.POST],
         produces = [MediaType.APPLICATION_JSON_VALUE],

--- a/api/src/main/kotlin/router/docs/AuthDocs.kt
+++ b/api/src/main/kotlin/router/docs/AuthDocs.kt
@@ -168,6 +168,54 @@ import org.springframework.web.bind.annotation.RequestMethod
             ),
     ),
     RouterOperation(
+        path = "/v1/auth/login_apple",
+        method = [RequestMethod.POST],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        operation =
+            Operation(
+                operationId = "loginAppleLegacy",
+                requestBody =
+                    RequestBody(
+                        content = [
+                            Content(
+                                schema = Schema(implementation = SocialLoginRequest::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            ),
+                        ],
+                    ),
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = LoginResponse::class))],
+                    ),
+                ],
+            ),
+    ),
+    RouterOperation(
+        path = "/v1/auth/login/apple",
+        method = [RequestMethod.POST],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        operation =
+            Operation(
+                operationId = "loginApple",
+                requestBody =
+                    RequestBody(
+                        content = [
+                            Content(
+                                schema = Schema(implementation = SocialLoginRequest::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            ),
+                        ],
+                    ),
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = LoginResponse::class))],
+                    ),
+                ],
+            ),
+    ),
+    RouterOperation(
         path = "/v1/auth/logout",
         method = [RequestMethod.POST],
         produces = [MediaType.APPLICATION_JSON_VALUE],

--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -55,6 +55,7 @@ enum class ErrorType(
     UPDATE_APP_VERSION(HttpStatus.BAD_REQUEST, 40021, "앱 버전을 업데이트해주세요.", "앱 버전을 업데이트해주세요."),
 
     SOCIAL_CONNECT_FAIL(HttpStatus.UNAUTHORIZED, 40100, "소셜 로그인에 실패했습니다.", "소셜 로그인에 실패했습니다."),
+    INVALID_APPLE_LOGIN_TOKEN(HttpStatus.UNAUTHORIZED, 40101, "유효하지 않은 애플 로그인 토큰입니다.", "소셜 로그인에 실패했습니다."),
 
     TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "timetable_id가 유효하지 않습니다", "존재하지 않는 시간표입니다."),
     PRIMARY_TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "timetable_id가 유효하지 않습니다", "대표 시간표가 존재하지 않습니다."),

--- a/core/src/main/kotlin/common/exception/Snu4tException.kt
+++ b/core/src/main/kotlin/common/exception/Snu4tException.kt
@@ -82,6 +82,8 @@ object UpdateAppVersionException : Snu4tException(ErrorType.UPDATE_APP_VERSION)
 
 object SocialConnectFailException : Snu4tException(ErrorType.SOCIAL_CONNECT_FAIL)
 
+object InvalidAppleLoginTokenException : Snu4tException(ErrorType.INVALID_APPLE_LOGIN_TOKEN)
+
 object NoUserFcmKeyException : Snu4tException(ErrorType.NO_USER_FCM_KEY)
 
 object InvalidRegistrationForPreviousSemesterCourseException :

--- a/core/src/main/kotlin/users/dto/SocialLoginRequest.kt
+++ b/core/src/main/kotlin/users/dto/SocialLoginRequest.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.snu4t.users.dto
 import com.fasterxml.jackson.annotation.JsonAlias
 
 data class SocialLoginRequest(
-    @JsonAlias("fb_token")
+    @JsonAlias("fb_token", "apple_token")
     val token: String,
 )


### PR DESCRIPTION
- 로컬 테스트 통과하게끔 `AppleClient` 수정
- `extractJwtHeader` 메서드 수정: signing key 명시하지 않으면 에러가 발생하여 base64 디코딩으로 헤더 추출
- apple jwk 응답 포맷에 맞게 `webClient.get`에 사용되는 타입 수정
- `login_apple` 레거시 엔드포인트 추가
- 애플 로그인 관련 docs 추가 