### PR TITLE
시간표 강의 업데이트 개별로 일어나도록 설정

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snu4t.sugangsnu.job.sync.service
 
 import com.wafflestudio.snu4t.bookmark.repository.BookmarkRepository
-import com.wafflestudio.snu4t.common.cache.Cache
 import com.wafflestudio.snu4t.coursebook.data.Coursebook
 import com.wafflestudio.snu4t.coursebook.repository.CoursebookRepository
 import com.wafflestudio.snu4t.lecturebuildings.data.Campus
@@ -55,7 +54,6 @@ class SugangSnuSyncServiceImpl(
     private val bookmarkRepository: BookmarkRepository,
     private val tagListRepository: TagListRepository,
     private val lectureBuildingService: LectureBuildingService,
-    private val cache: Cache,
 ) : SugangSnuSyncService {
     override suspend fun updateCoursebook(coursebook: Coursebook): List<UserLectureSyncResult> {
         val courseNumberCategoryPre2025Map = categoryPre2025FetchService.getCategoriesPre2025()
@@ -200,8 +198,7 @@ class SugangSnuSyncServiceImpl(
             updatedLecture.oldData.semester,
             updatedLecture.oldData.id!!,
         ).map { bookmark ->
-            bookmark.apply {
-                lectures.find { it.id == updatedLecture.oldData.id }?.apply {
+            val updatedBookmarkLecture = bookmark.lectures.find { it.id == updatedLecture.oldData.id }?.apply {
                     academicYear = updatedLecture.newData.academicYear
                     category = updatedLecture.newData.category
                     classPlaceAndTimes = updatedLecture.newData.classPlaceAndTimes
@@ -216,10 +213,8 @@ class SugangSnuSyncServiceImpl(
                     courseNumber = updatedLecture.newData.courseNumber
                     courseTitle = updatedLecture.newData.courseTitle
                     categoryPre2025 = updatedLecture.newData.categoryPre2025
-                }
-            }
-        }.let {
-            bookmarkRepository.saveAll(it)
+            }!!
+            bookmarkRepository.updateLecture(bookmark.id!!, updatedBookmarkLecture)
         }.map { bookmark ->
             BookmarkLectureUpdateResult(
                 bookmark.year,
@@ -254,27 +249,23 @@ class SugangSnuSyncServiceImpl(
         updatedLecture: UpdatedLecture,
     ): Flow<TimetableLectureUpdateResult> =
         timetables.map { timetable ->
-            timetable.apply {
-                lectures.find { it.lectureId == updatedLecture.oldData.id }?.apply {
-                    academicYear = updatedLecture.newData.academicYear
-                    category = updatedLecture.newData.category
-                    classPlaceAndTimes = updatedLecture.newData.classPlaceAndTimes
-                    classification = updatedLecture.newData.classification
-                    credit = updatedLecture.newData.credit
-                    department = updatedLecture.newData.department
-                    instructor = updatedLecture.newData.instructor
-                    lectureNumber = updatedLecture.newData.lectureNumber
-                    quota = updatedLecture.newData.quota
-                    freshmanQuota = updatedLecture.newData.freshmanQuota
-                    remark = updatedLecture.newData.remark
-                    courseNumber = updatedLecture.newData.courseNumber
-                    courseTitle = updatedLecture.newData.courseTitle
-                    categoryPre2025 = updatedLecture.newData.categoryPre2025
-                }
-                updatedAt = Instant.now()
+            val updatedTimetableLecture = timetable.lectures.find { it.lectureId == updatedLecture.oldData.id }?.apply {
+                academicYear = updatedLecture.newData.academicYear
+                category = updatedLecture.newData.category
+                classPlaceAndTimes = updatedLecture.newData.classPlaceAndTimes
+                classification = updatedLecture.newData.classification
+                credit = updatedLecture.newData.credit
+                department = updatedLecture.newData.department
+                instructor = updatedLecture.newData.instructor
+                lectureNumber = updatedLecture.newData.lectureNumber
+                quota = updatedLecture.newData.quota
+                freshmanQuota = updatedLecture.newData.freshmanQuota
+                remark = updatedLecture.newData.remark
+                courseNumber = updatedLecture.newData.courseNumber
+                courseTitle = updatedLecture.newData.courseTitle
+                categoryPre2025 = updatedLecture.newData.categoryPre2025
             }
-        }.let {
-            timeTableRepository.saveAll(it)
+            timeTableRepository.updateTimetableLecture(timetable.id!!, updatedTimetableLecture!!)
         }.map { timetable ->
             TimetableLectureUpdateResult(
                 year = timetable.year,

--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -198,7 +198,8 @@ class SugangSnuSyncServiceImpl(
             updatedLecture.oldData.semester,
             updatedLecture.oldData.id!!,
         ).map { bookmark ->
-            val updatedBookmarkLecture = bookmark.lectures.find { it.id == updatedLecture.oldData.id }?.apply {
+            val updatedBookmarkLecture =
+                bookmark.lectures.find { it.id == updatedLecture.oldData.id }?.apply {
                     academicYear = updatedLecture.newData.academicYear
                     category = updatedLecture.newData.category
                     classPlaceAndTimes = updatedLecture.newData.classPlaceAndTimes
@@ -213,7 +214,7 @@ class SugangSnuSyncServiceImpl(
                     courseNumber = updatedLecture.newData.courseNumber
                     courseTitle = updatedLecture.newData.courseTitle
                     categoryPre2025 = updatedLecture.newData.categoryPre2025
-            }!!
+                }!!
             bookmarkRepository.updateLecture(bookmark.id!!, updatedBookmarkLecture)
         }.map { bookmark ->
             BookmarkLectureUpdateResult(
@@ -249,22 +250,23 @@ class SugangSnuSyncServiceImpl(
         updatedLecture: UpdatedLecture,
     ): Flow<TimetableLectureUpdateResult> =
         timetables.map { timetable ->
-            val updatedTimetableLecture = timetable.lectures.find { it.lectureId == updatedLecture.oldData.id }?.apply {
-                academicYear = updatedLecture.newData.academicYear
-                category = updatedLecture.newData.category
-                classPlaceAndTimes = updatedLecture.newData.classPlaceAndTimes
-                classification = updatedLecture.newData.classification
-                credit = updatedLecture.newData.credit
-                department = updatedLecture.newData.department
-                instructor = updatedLecture.newData.instructor
-                lectureNumber = updatedLecture.newData.lectureNumber
-                quota = updatedLecture.newData.quota
-                freshmanQuota = updatedLecture.newData.freshmanQuota
-                remark = updatedLecture.newData.remark
-                courseNumber = updatedLecture.newData.courseNumber
-                courseTitle = updatedLecture.newData.courseTitle
-                categoryPre2025 = updatedLecture.newData.categoryPre2025
-            }
+            val updatedTimetableLecture =
+                timetable.lectures.find { it.lectureId == updatedLecture.oldData.id }?.apply {
+                    academicYear = updatedLecture.newData.academicYear
+                    category = updatedLecture.newData.category
+                    classPlaceAndTimes = updatedLecture.newData.classPlaceAndTimes
+                    classification = updatedLecture.newData.classification
+                    credit = updatedLecture.newData.credit
+                    department = updatedLecture.newData.department
+                    instructor = updatedLecture.newData.instructor
+                    lectureNumber = updatedLecture.newData.lectureNumber
+                    quota = updatedLecture.newData.quota
+                    freshmanQuota = updatedLecture.newData.freshmanQuota
+                    remark = updatedLecture.newData.remark
+                    courseNumber = updatedLecture.newData.courseNumber
+                    courseTitle = updatedLecture.newData.courseTitle
+                    categoryPre2025 = updatedLecture.newData.categoryPre2025
+                }
             timeTableRepository.updateTimetableLecture(timetable.id!!, updatedTimetableLecture!!)
         }.map { timetable ->
             TimetableLectureUpdateResult(

--- a/core/src/main/kotlin/bookmark/repository/BookmarkCustomRepository.kt
+++ b/core/src/main/kotlin/bookmark/repository/BookmarkCustomRepository.kt
@@ -108,7 +108,10 @@ class BookmarkCustomRepositoryImpl(private val reactiveMongoTemplate: ReactiveMo
         ).findModifyAndAwait()
     }
 
-    override suspend fun updateLecture(bookmarkId: String, lecture: BookmarkLecture): Bookmark {
+    override suspend fun updateLecture(
+        bookmarkId: String,
+        lecture: BookmarkLecture,
+    ): Bookmark {
         return reactiveMongoTemplate.update<Bookmark>().matching(
             Bookmark::id.isEqualTo(bookmarkId).and("lectures._id").isEqualTo(ObjectId(lecture.id)),
         ).apply(Update().set("""lectures.$""", lecture))

--- a/core/src/main/kotlin/timetables/repository/TimetableCustomRepository.kt
+++ b/core/src/main/kotlin/timetables/repository/TimetableCustomRepository.kt
@@ -152,7 +152,7 @@ class TimetableCustomRepositoryImpl(
     ): Timetable =
         reactiveMongoTemplate.update<Timetable>().matching(
             Timetable::id.isEqualTo(timeTableId).and("lecture_list._id").isEqualTo(ObjectId(timetableLecture.id)),
-        ).apply(Update().apply { set("""lecture_list.$""", timetableLecture) })
+        ).apply(Update().apply { set("""lecture_list.$""", timetableLecture) }.currentDate(Timetable::updatedAt.toDotPath()))
             .withOptions(FindAndModifyOptions.options().returnNew(true)).findModifyAndAwait()
 
     override suspend fun findLatestChildTimetable(


### PR DESCRIPTION
원래 timetable 단위로 저장했는데 
lecture list read 타이밍 이슈로 여러 쿼리가 한 timetable에 적용되는 경우 변경사항이 덮어써짐

timetableLecture 개별 update로 막음