### PR TITLE
email regex 변경

### DIFF
--- a/core/src/main/kotlin/users/service/AuthService.kt
+++ b/core/src/main/kotlin/users/service/AuthService.kt
@@ -58,7 +58,7 @@ class AuthServiceImpl(
     companion object {
         private val localIdRegex = """^[a-zA-Z0-9]{4,32}$""".toRegex()
         private val passwordRegex = """^(?=.*\d)(?=.*[a-zA-Z])\S{6,20}$""".toRegex()
-        private val emailRegex = """^[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*@[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*.[a-zA-Z]{2,3}$""".toRegex()
+        private val emailRegex = """^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$""".toRegex()
     }
 
     private val clients = clients.mapKeys { AuthProvider.valueOf(it.key) }


### PR DESCRIPTION
https://github.com/wafflestudio/snutt-feedbacks/issues/1424

> 이메일: `_syshine@snu.ac.kr`
> 플랫폼/디바이스: ios (16.0.1) / iPhone14,7
> 버전: 3.8.2
> 프로필: prod
> 날짜/시간(UTC+9): 2025-01-30T21:55:14.403002796
> 
> 서울대 이메일 주소가 _syshine@snu.ac.kr인데 이메일 형식이 올바르지 않다고 뜨고, 회원가입 및 로그인이 정상적으로 진행되지 않아 문의드립니다.

underscore로 시작하는 이메일도 대응

[RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1)
대충 반영해서 웬만한 문자 다 가능하도록 변경

