### PR TITLE
logout을 UserHandler로 이동

### DIFF
--- a/api/src/main/kotlin/handler/AuthHandler.kt
+++ b/api/src/main/kotlin/handler/AuthHandler.kt
@@ -7,7 +7,6 @@ import com.wafflestudio.snutt.users.dto.FacebookLoginRequest
 import com.wafflestudio.snutt.users.dto.GetMaskedEmailRequest
 import com.wafflestudio.snutt.users.dto.LocalLoginRequest
 import com.wafflestudio.snutt.users.dto.LocalRegisterRequest
-import com.wafflestudio.snutt.users.dto.LogoutRequest
 import com.wafflestudio.snutt.users.dto.PasswordResetRequest
 import com.wafflestudio.snutt.users.dto.SendEmailRequest
 import com.wafflestudio.snutt.users.dto.SocialLoginRequest
@@ -71,15 +70,6 @@ class AuthHandler(
         handle(req) {
             val socialLoginRequest: SocialLoginRequest = req.awaitBodyOrNull() ?: throw ServerWebInputException("Invalid body")
             userService.loginApple(socialLoginRequest)
-        }
-
-    suspend fun logout(req: ServerRequest): ServerResponse =
-        handle(req) {
-            val userId = req.userId
-            val logoutRequest: LogoutRequest = req.awaitBodyOrNull() ?: throw ServerWebInputException("Invalid body")
-            userService.logout(userId, logoutRequest)
-
-            OkResponse()
         }
 
     suspend fun findId(req: ServerRequest): ServerResponse =

--- a/api/src/main/kotlin/handler/UserHandler.kt
+++ b/api/src/main/kotlin/handler/UserHandler.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.snutt.users.data.User
 import com.wafflestudio.snutt.users.dto.AuthProvidersCheckDto
 import com.wafflestudio.snutt.users.dto.EmailVerificationResultDto
 import com.wafflestudio.snutt.users.dto.LocalLoginRequest
+import com.wafflestudio.snutt.users.dto.LogoutRequest
 import com.wafflestudio.snutt.users.dto.PasswordChangeRequest
 import com.wafflestudio.snutt.users.dto.SendEmailRequest
 import com.wafflestudio.snutt.users.dto.SocialLoginRequest
@@ -21,6 +22,8 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.awaitBody
+import org.springframework.web.reactive.function.server.awaitBodyOrNull
+import org.springframework.web.server.ServerWebInputException
 
 @Component
 class UserHandler(
@@ -172,6 +175,15 @@ class UserHandler(
             val user = req.getContext().user!!
             val body = req.awaitBody<PasswordChangeRequest>()
             userService.changePassword(user, body)
+        }
+
+    suspend fun logout(req: ServerRequest): ServerResponse =
+        handle(req) {
+            val userId = req.userId
+            val logoutRequest: LogoutRequest = req.awaitBodyOrNull() ?: throw ServerWebInputException("Invalid body")
+            userService.logout(userId, logoutRequest)
+
+            OkResponse()
         }
 
     private fun buildUserDto(user: User) =

--- a/api/src/main/kotlin/router/MainRouter.kt
+++ b/api/src/main/kotlin/router/MainRouter.kt
@@ -90,7 +90,7 @@ class MainRouter(
                 POST("/login/kakao", authHandler::loginKakao)
                 POST("/login_apple", authHandler::loginAppleLegacy)
                 POST("/login/apple", authHandler::loginApple)
-                POST("/logout", authHandler::logout)
+                POST("/logout", userHandler::logout)
                 POST("/password/reset/email/check", authHandler::getMaskedEmail)
                 POST("/password/reset/email/send", authHandler::sendResetPasswordCode)
                 POST("/password/reset/verification/code", authHandler::verifyResetPasswordCode)


### PR DESCRIPTION
기존 logout api가 AuthHandler에 위치했는데 이게 SnuttRestApiNoAuthMiddleware를 사용하고 있어서 요청의 유저 토큰을 가져오지 못했고 로그아웃이 안됐었어요
경로는 그대로 두고 UserHandler로 옮겨서 제대로 작동하게 만들었습니다