### PR TITLE
푸시 설정 조회되지 않으면 푸시 허용으로 로직 수정

### DIFF
--- a/core/src/main/kotlin/notification/data/PushPreferenceType.kt
+++ b/core/src/main/kotlin/notification/data/PushPreferenceType.kt
@@ -1,9 +1,9 @@
 package com.wafflestudio.snutt.notification.data
 
-enum class PushPreferenceType {
-    NORMAL,
-    LECTURE_UPDATE,
-    VACANCY_NOTIFICATION,
+enum class PushPreferenceType(val isEnabledByDefault: Boolean) {
+    NORMAL(true),
+    LECTURE_UPDATE(true),
+    VACANCY_NOTIFICATION(true),
 }
 
 fun PushPreferenceType(notificationType: NotificationType) =

--- a/core/src/main/kotlin/notification/service/PushPreferenceService.kt
+++ b/core/src/main/kotlin/notification/service/PushPreferenceService.kt
@@ -50,16 +50,11 @@ class PushPreferenceServiceImpl(
             ?.let { PushPreferenceDto(it) }
             ?: PushPreferenceDto(
                 pushPreferences =
-                    listOf(
-                        PushPreferenceItem(
-                            type = PushPreferenceType.LECTURE_UPDATE,
-                            isEnabled = true,
-                        ),
-                        PushPreferenceItem(
-                            type = PushPreferenceType.VACANCY_NOTIFICATION,
-                            isEnabled = true,
-                        ),
-                    ),
+                    PushPreferenceType.entries
+                        .filterNot { it == PushPreferenceType.NORMAL }
+                        .map {
+                            PushPreferenceItem(type = it, isEnabled = true)
+                        },
             )
 
     override suspend fun isPushPreferenceEnabled(

--- a/core/src/main/kotlin/notification/service/PushPreferenceService.kt
+++ b/core/src/main/kotlin/notification/service/PushPreferenceService.kt
@@ -35,12 +35,22 @@ class PushPreferenceServiceImpl(
         user: User,
         pushPreferenceDto: PushPreferenceDto,
     ) {
+        val pushPreferenceDtoMap = pushPreferenceDto.pushPreferences.associate { it.type to it.isEnabled }
+
+        val pushPreferenceItemsWithDefault =
+            PushPreferenceType.entries.map {
+                PushPreferenceItem(
+                    type = it,
+                    isEnabled = pushPreferenceDtoMap[it] ?: it.isEnabledByDefault,
+                )
+            }
+
         pushPreferenceRepository.save(
             pushPreferenceRepository.findByUserId(user.id!!)
-                ?.copy(pushPreferences = pushPreferenceDto.pushPreferences)
+                ?.copy(pushPreferences = pushPreferenceItemsWithDefault)
                 ?: PushPreference(
                     userId = user.id,
-                    pushPreferences = pushPreferenceDto.pushPreferences,
+                    pushPreferences = pushPreferenceItemsWithDefault,
                 ),
         )
     }


### PR DESCRIPTION
- https://wafflestudio.slack.com/archives/C8M9NUBBR/p1747800559052039
- https://wafflestudio.slack.com/archives/C0PAVPS5T/p1747889296597229?thread_ts=1745418731.228439&cid=C0PAVPS5T

- PushPreference가 DB에서 조회되지 않으면 해당 사용자는 카테고리별 푸시 설정이 ON 인 것으로 로직 수정