### PR TITLE
[강의 리마인더] 동일한 알림을 10분 간격으로 2번 보내는 버그 수정

### DIFF
--- a/core/src/main/kotlin/timetablelecturereminder/repository/TimetableLectureReminderCustomRepository.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/repository/TimetableLectureReminderCustomRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.find
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.mongodb.core.query.elemMatch
-import org.springframework.data.mongodb.core.query.gte
+import org.springframework.data.mongodb.core.query.gt
 import org.springframework.data.mongodb.core.query.isEqualTo
 import org.springframework.data.mongodb.core.query.lt
 import org.springframework.data.mongodb.core.query.lte
@@ -36,7 +36,7 @@ class TimetableLectureReminderCustomRepositoryImpl(
                 Criteria().andOperator(
                     TimetableLectureReminder.Schedule::day isEqualTo dayOfWeek,
                     Criteria().andOperator(
-                        TimetableLectureReminder.Schedule::minute gte startMinute,
+                        TimetableLectureReminder.Schedule::minute gt startMinute,
                         TimetableLectureReminder.Schedule::minute lte endMinute,
                     ),
                     Criteria().orOperator(


### PR DESCRIPTION
- 가끔씩 동일한 알림을 10분 간격으로 2번 보내는 버그가 있습니다(예: 03:30에 한번 보내고, 03:40에 또 한번 보냄)
- 대상 리마인더를 가져오는 시간 조건이 [-10분전, 현재] 이었던 것을 (-10분전, 현재] 로 바꾸었습니다