### PR TITLE
[강의 리마인더] 안드로이드 기기에 FCM 푸시가 바로 가지 않는 버그 수정

### DIFF
--- a/core/src/main/kotlin/common/push/dto/PushMessages.kt
+++ b/core/src/main/kotlin/common/push/dto/PushMessages.kt
@@ -32,6 +32,7 @@ data class PushMessage(
     val body: String,
     val urlScheme: DeeplinkType? = null,
     val data: Data = Data(emptyMap()),
+    val isUrgentOnAndroid: Boolean = false, // true라면 안드로이드 doze 모드(배터리 절약 모드) 중에 기기를 깨우고 정확한 알림을 보낸다
 ) {
     data class Data(
         val payload: Map<String, String>,

--- a/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
+++ b/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.common.push.fcm
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.AndroidConfig
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.Notification
@@ -105,6 +106,12 @@ internal class FcmPushClient(
                 .setTitle(message.title)
                 .setBody(message.body)
                 .build()
+        val androidConfig =
+            AndroidConfig
+                .builder()
+                .setPriority(
+                    if (message.isUrgentOnAndroid) AndroidConfig.Priority.HIGH else AndroidConfig.Priority.NORMAL,
+                ).build()
         return Message.builder().run {
             when (this@toFcmMessage) {
                 is TargetedPushMessageWithToken -> setToken(targetToken)
@@ -112,6 +119,7 @@ internal class FcmPushClient(
             }
             message.urlScheme?.let { putData(PayloadKeys.URL_SCHEME, it.build().value) }
             setNotification(notification)
+            setAndroidConfig(androidConfig)
             putAllData(message.data.payload)
             build()
         }

--- a/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderNotifierService.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderNotifierService.kt
@@ -216,8 +216,9 @@ class TimetableLectureReminderNotifierServiceImpl(
             }
 
         return PushMessage(
-            pushTitle,
-            pushBody,
+            title = pushTitle,
+            body = pushBody,
+            isUrgentOnAndroid = true,
         )
     }
 }


### PR DESCRIPTION
- 안드로이드는 일정 시간 이상 기기를 사용하지 않으면 doze 모드로 들어가서 네트워크 통신과 FCM 수신 등을 미룸([참고](https://jtm0609.tistory.com/233))
- 따라서 doze 모드일 때 푸시를 보내면 정확한 시각에 푸시를 받지 못하는 문제가 있음
- 다행히 doze 모드더라도 기기를 바로 깨우는 기능이 있어서(`AndroidConfig.Priority.HIGH`)
- `PushMessage`에 `isUrgentOnAndroid` 라는 필드를 두고 얘가 true라면 기기 깨우게 합니다