### PR TITLE
[강의 리마인더] 수강스누 배치로 인해 강의 시간이 변경되는 경우 대응

### DIFF
--- a/core/src/main/kotlin/timetablelecturereminder/repository/TimetableLectureReminderRepository.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/repository/TimetableLectureReminderRepository.kt
@@ -9,4 +9,6 @@ interface TimetableLectureReminderRepository :
     suspend fun findByTimetableLectureId(timetableLectureId: String): TimetableLectureReminder?
 
     suspend fun findByTimetableLectureIdIn(timetableLectureIds: List<String>): List<TimetableLectureReminder>
+
+    suspend fun deleteByTimetableLectureId(timetableLectureId: String)
 }

--- a/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
@@ -117,9 +117,9 @@ class TimetableLectureServiceImpl(
             categoryPre2025 = originalLecture.categoryPre2025
         }
         resolveTimeConflict(timetable, timetableLecture, isForced)
-        val updatedTimetable = timetableRepository.updateTimetableLecture(timetableId, timetableLecture)
-        eventPublisher.publishEvent(TimetableLectureModifiedEvent(timetableLecture))
-        return updatedTimetable
+        return timetableRepository.updateTimetableLecture(timetableId, timetableLecture).also {
+            eventPublisher.publishEvent(TimetableLectureModifiedEvent(timetableLecture))
+        }
     }
 
     override suspend fun modifyTimetableLecture(
@@ -149,9 +149,9 @@ class TimetableLectureServiceImpl(
             categoryPre2025 = modifyTimetableLectureRequestDto.categoryPre2025 ?: categoryPre2025
         }
         resolveTimeConflict(timetable, timetableLecture, isForced)
-        val updatedTimetable = timetableRepository.updateTimetableLecture(timetableId, timetableLecture)
-        eventPublisher.publishEvent(TimetableLectureModifiedEvent(timetableLecture))
-        return updatedTimetable
+        return timetableRepository.updateTimetableLecture(timetableId, timetableLecture).also {
+            eventPublisher.publishEvent(TimetableLectureModifiedEvent(timetableLecture))
+        }
     }
 
     override suspend fun deleteTimetableLecture(


### PR DESCRIPTION
## 배경
- 강의의 시간이 수정되면, 강의 리마인더의 시간도 수정해야 함
- 유저가 시간을 수정한 경우는 대응했는데, 수강스누 배치로 인해 시간이 수정되는 경우는 대응하지 못했음

## 변경사항
- `SugangSnuSyncService::updateTimetableLecture()`에서 `TimetableLectureMofiedEvent`를 쏩니다(유저가 강의 수정한 경우와 마찬가지) 051c479be43780e36102343a8a53a02d23337a59
- 모든 강의마다 `TimetableLectureReminder` find, update 쿼리가 추가로 나갈 거라서, 분기로 쿼리 횟수를 최소화했어요 d800ba0e86aa9a283469103ab48e870748eb2393