### PR TITLE
native 빌드에서 G1 GC 사용

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -28,7 +28,6 @@ graalvmNative {
         named("main") {
             buildArgs.add("--gc=G1")
             buildArgs.add("-R:MaxRAMPercentage=60.0")
-            buildArgs.add("-R:MaxGCPauseMillis=100")
         }
     }
 }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -22,3 +22,13 @@ dependencies {
 tasks.bootJar {
     archiveFileName.set("snutt-api.jar")
 }
+
+graalvmNative {
+    binaries {
+        named("main") {
+            buildArgs.add("--gc=G1")
+            buildArgs.add("-R:MaxRAMPercentage=60.0")
+            buildArgs.add("-R:MaxGCPauseMillis=100")
+        }
+    }
+}


### PR DESCRIPTION
G1 GC를 쓰기에는 cpu limit이 좀 작은거 같긴 한데 (200m)
적용해보고 느려지는거 같으면 cpu는 램에 비해서 덜 부족하니 좀 올려 보고 안된다 싶으면 롤백할게요