### PR TITLE
mongodb 드라이버 5.6.2 -> 5.5.2 다운그레이드

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,6 +13,12 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
     api("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
 
+    // TODO: https://jira.mongodb.org/browse/JAVA-6038 이슈 해결된 spring-boot-starter-data-mongodb 업그레이드 후 아래 의존성 삭제
+    api("org.mongodb:mongodb-driver-sync:5.5.2")
+    api("org.mongodb:bson:5.5.2")
+    api("org.mongodb:mongodb-driver-core:5.5.2")
+    api("org.mongodb:bson-record-codec:5.5.2")
+
     api("org.springframework.boot:spring-boot-starter-data-redis")
 
     implementation("org.springframework.security:spring-security-crypto")


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-6038
해당 이슈로 인해 
`io.netty.util.ResourceLeakDetector : LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.` 이 에러 로그가 너무 자주 떠서 일단 mongodb 드라이버를 5.5.2로 롤백
