### PR TITLE
jackson fail-on-null-for-primitives 옵션 변경

### DIFF
--- a/core/src/main/resources/application-common.yml
+++ b/core/src/main/resources/application-common.yml
@@ -9,6 +9,9 @@ spring:
         enabled: false
       host:
       database:
+  jackson:
+    deserialization:
+      fail-on-null-for-primitives: false
 
 google:
   firebase:


### PR DESCRIPTION
jackson 2.x버전에서는 FAIL_ON_NULL_FOR_PRIMITIVES 옵션이 default false였으나 3.x 부터 true로 변경됨
이 옵션이 true일 때 kotlin과 함께 사용하면 jackson 코틀린 모듈보다 null 체크가 먼저 들어가기 때문에 kotlin 에서 기본값을 설정해줘도 그 전에 터짐

ex)
```kotlin
data class SnuMapSearchItem(
    @param:JsonProperty("lat_val1")
    val latitudeInDecimal: Double = 0.0,
)
```
해당 클래스로 `lat_val1`이 없는 json 읽을 시 null 체크

해당 옵션 false로 변경