### PR TITLE
logout에 SnuttDefaultApiFilterTarget 적용

### DIFF
--- a/api/src/main/kotlin/controller/AuthController.kt
+++ b/api/src/main/kotlin/controller/AuthController.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt.controller
 
 import com.wafflestudio.snutt.common.dto.OkResponse
 import com.wafflestudio.snutt.config.CurrentUser
+import com.wafflestudio.snutt.filter.SnuttDefaultApiFilterTarget
 import com.wafflestudio.snutt.filter.SnuttNoAuthApiFilterTarget
 import com.wafflestudio.snutt.users.data.User
 import com.wafflestudio.snutt.users.dto.EmailResponse
@@ -108,6 +109,7 @@ class AuthController(
         return OkResponse()
     }
 
+    @SnuttDefaultApiFilterTarget
     @PostMapping("/logout")
     suspend fun logout(
         @CurrentUser user: User,


### PR DESCRIPTION
기존에 SnuttNoAuthApiFilterTarget이 달려있어서 로그아웃에 403 오는 문제 수정했어요