### PR TITLE
MongoDB Driver 5.5.2로 다운그레이드 (ByteBuf leak 회피)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,15 @@ subprojects {
         imports {
             mavenBom("org.springframework.boot:spring-boot-dependencies:4.0.1")
         }
+        dependencies {
+            // Downgrade MongoDB driver to avoid ByteBuf leak (JAVA-6038)
+            dependency("org.mongodb:mongodb-driver-core:5.5.2")
+            dependency("org.mongodb:mongodb-driver-sync:5.5.2")
+            dependency("org.mongodb:mongodb-driver-reactivestreams:5.5.2")
+            dependency("org.mongodb:bson:5.5.2")
+            dependency("org.mongodb:bson-record-codec:5.5.2")
+            dependency("org.mongodb:bson-kotlin:5.5.2")
+        }
     }
 
     tasks.withType<KotlinCompile> {


### PR DESCRIPTION
이전에 했던건 제대로 오버라이드가 안됐었는데 이렇게 하니까 로컬에서 테스트해볼 때는 leak 안나네요