### PR TITLE
비밀번호 초기화 과정 변경

### DIFF
--- a/api/src/main/kotlin/controller/AuthController.kt
+++ b/api/src/main/kotlin/controller/AuthController.kt
@@ -92,7 +92,8 @@ class AuthController(
     suspend fun verifyResetPasswordCode(
         @RequestBody body: VerificationCodeRequest,
     ): OkResponse {
-        userService.verifyResetPasswordCode(body.userId!!, body.code)
+        val user = userService.getUser(body.userId!!)
+        userService.verifyResetPasswordCode(user, body.code)
         return OkResponse()
     }
 

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -118,7 +118,7 @@ interface UserService {
     suspend fun sendResetPasswordCode(email: String)
 
     suspend fun verifyResetPasswordCode(
-        localId: String,
+        user: User,
         code: String,
     )
 
@@ -567,13 +567,12 @@ class UserServiceImpl(
     }
 
     override suspend fun verifyResetPasswordCode(
-        localId: String,
+        user: User,
         code: String,
     ) {
-        val user = userRepository.findByCredentialLocalIdAndActiveTrue(localId) ?: throw UserNotFoundException
         val key = RESET_PASSWORD_CODE_PREFIX + user.id
         checkVerificationValue(key, code)
-        redisTemplate.expire(key, Duration.ofMinutes(3)).subscribe()
+        redisTemplate.expire(key, Duration.ofHours(1)).subscribe()
     }
 
     override suspend fun getMaskedEmail(localId: String): String {
@@ -589,7 +588,7 @@ class UserServiceImpl(
         code: String,
     ) {
         val user = userRepository.findByCredentialLocalIdAndActiveTrue(localId) ?: throw UserNotFoundException
-        verifyResetPasswordCode(localId, code)
+        verifyResetPasswordCode(user, code)
         if (!authService.isValidPassword(newPassword)) throw InvalidPasswordException
         user.apply {
             credential.localPw = authService.buildLocalCredential(user.credential.localId!!, newPassword).localPw


### PR DESCRIPTION
user 조회가 2번 들어가는거 없앴고, 코드 입력 후 유효기간을 1시간으로 연장하여 코드 입력 후에 오는 3분 타이머는 삭제하는 방향으로 하면 좋을거 같아요
이전 api랑 호환성도 괜찮고

https://wafflestudio.slack.com/archives/C04T7UW3U8G/p1770464790385019?thread_ts=1770434088.137649&cid=C04T7UW3U8G