### PR TITLE
OIDC 리팩토링 및 Facebook OIDC 로그인 추가

### DIFF
--- a/core/src/main/kotlin/auth/apple/AppleClient.kt
+++ b/core/src/main/kotlin/auth/apple/AppleClient.kt
@@ -2,54 +2,36 @@ package com.wafflestudio.snutt.auth.apple
 
 import com.wafflestudio.snutt.auth.OAuth2Client
 import com.wafflestudio.snutt.auth.OAuth2UserResponse
+import com.wafflestudio.snutt.auth.oidc.OidcJwtVerifier
+import com.wafflestudio.snutt.auth.oidc.OidcVerificationOptions
 import com.wafflestudio.snutt.common.exception.InvalidAppleLoginTokenException
-import com.wafflestudio.snutt.common.extension.get
-import io.jsonwebtoken.Jwts
-import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
-import reactor.netty.http.client.HttpClient
-import tools.jackson.databind.ObjectMapper
-import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.PublicKey
-import java.security.spec.RSAPublicKeySpec
-import java.time.Duration
-import java.util.Base64
 
 @Component("APPLE")
-@RegisterReflectionForBinding(AppleJwk::class)
 class AppleClient(
-    private val objectMapper: ObjectMapper,
+    private val oidcJwtVerifier: OidcJwtVerifier,
+    @param:Value("\${oidc.apple.app-id:}") private val appleAppId: String,
 ) : OAuth2Client {
-    private val webClient =
-        WebClient
-            .builder()
-            .clientConnector(
-                ReactorClientHttpConnector(
-                    HttpClient.create().responseTimeout(
-                        Duration.ofSeconds(3),
-                    ),
-                ),
-            ).build()
-
     companion object {
         private const val APPLE_JWK_URI = "https://appleid.apple.com/auth/keys"
+        private const val APPLE_ISSUER = "https://appleid.apple.com"
     }
 
     override suspend fun getMe(token: String): OAuth2UserResponse? {
-        val jwtHeader = extractJwtHeader(token)
-        val appleJwk =
-            webClient
-                .get<Map<String, List<AppleJwk>>>(uri = APPLE_JWK_URI)
-                .getOrNull()
-                ?.get("keys")
-                ?.find {
-                    it.kid == jwtHeader.kid && it.alg == jwtHeader.alg
-                } ?: return null
-        val publicKey = convertJwkToPublicKey(appleJwk)
-        val jwtPayload = verifyAndDecodeToken(token, publicKey)
+        if (!oidcJwtVerifier.looksLikeJwt(token)) throw InvalidAppleLoginTokenException
+
+        val jwtPayload =
+            oidcJwtVerifier.verifyAndDecodeToken(
+                token = token,
+                options =
+                    OidcVerificationOptions(
+                        jwksUri = APPLE_JWK_URI,
+                        expectedIssuer = APPLE_ISSUER,
+                        expectedAudience = appleAppId,
+                    ),
+            ) ?: return null
+
         val appleUserInfo = AppleUserInfo(jwtPayload)
         return OAuth2UserResponse(
             socialId = appleUserInfo.sub,
@@ -59,37 +41,4 @@ class AppleClient(
             transferInfo = appleUserInfo.transferSub,
         )
     }
-
-    private suspend fun extractJwtHeader(token: String): AppleJwtHeader {
-        val headerJson = Base64.getDecoder().decode(token.substringBefore(".")).toString(Charsets.UTF_8)
-        val headerMap = objectMapper.readValue(headerJson, Map::class.java)
-        val kid = headerMap["kid"] as? String ?: throw InvalidAppleLoginTokenException
-        val alg = headerMap["alg"] as? String ?: throw InvalidAppleLoginTokenException
-        return AppleJwtHeader(
-            kid = kid,
-            alg = alg,
-        )
-    }
-
-    private suspend fun convertJwkToPublicKey(jwk: AppleJwk): PublicKey {
-        val modulus = BigInteger(1, Base64.getUrlDecoder().decode(jwk.n))
-        val exponent = BigInteger(1, Base64.getUrlDecoder().decode(jwk.e))
-        val spec = RSAPublicKeySpec(modulus, exponent)
-        return KeyFactory.getInstance("RSA").generatePublic(spec)
-    }
-
-    private suspend fun verifyAndDecodeToken(
-        token: String,
-        publicKey: PublicKey,
-    ) = Jwts
-        .parser()
-        .verifyWith(publicKey)
-        .build()
-        .parseSignedClaims(token)
-        .payload
 }
-
-private data class AppleJwtHeader(
-    val kid: String,
-    val alg: String,
-)

--- a/core/src/main/kotlin/auth/facebook/FacebookClient.kt
+++ b/core/src/main/kotlin/auth/facebook/FacebookClient.kt
@@ -2,9 +2,12 @@ package com.wafflestudio.snutt.auth.facebook
 
 import com.wafflestudio.snutt.auth.OAuth2Client
 import com.wafflestudio.snutt.auth.OAuth2UserResponse
+import com.wafflestudio.snutt.auth.oidc.OidcJwtVerifier
+import com.wafflestudio.snutt.auth.oidc.OidcVerificationOptions
 import com.wafflestudio.snutt.common.extension.get
 import org.slf4j.LoggerFactory
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -13,7 +16,10 @@ import java.time.Duration
 
 @Component("FACEBOOK")
 @RegisterReflectionForBinding(FacebookOAuth2UserResponse::class)
-class FacebookClient : OAuth2Client {
+class FacebookClient(
+    private val oidcJwtVerifier: OidcJwtVerifier,
+    @param:Value("\${oidc.facebook.app-id:}") private val facebookAppId: String,
+) : OAuth2Client {
     private val log = LoggerFactory.getLogger(javaClass)
 
     private val httpClient = HttpClient.create().responseTimeout(Duration.ofSeconds(3))
@@ -25,9 +31,18 @@ class FacebookClient : OAuth2Client {
 
     companion object {
         private const val USER_INFO_URI = "https://graph.facebook.com/me"
+        private const val FACEBOOK_JWK_URI = "https://www.facebook.com/.well-known/oauth/openid/jwks/"
+        private const val FACEBOOK_ISSUER = "https://www.facebook.com"
     }
 
     override suspend fun getMe(token: String): OAuth2UserResponse? {
+        if (oidcJwtVerifier.looksLikeJwt(token)) {
+            getMeFromAuthenticationToken(token)?.let { return it }
+        }
+        return getMeFromAccessToken(token)
+    }
+
+    private suspend fun getMeFromAccessToken(token: String): OAuth2UserResponse? {
         val facebookUserResponse =
             webClient
                 .get<FacebookOAuth2UserResponse>(
@@ -45,5 +60,25 @@ class FacebookClient : OAuth2Client {
                 isEmailVerified = true,
             )
         }
+    }
+
+    private suspend fun getMeFromAuthenticationToken(token: String): OAuth2UserResponse? {
+        val claims =
+            oidcJwtVerifier.verifyAndDecodeToken(
+                token = token,
+                options =
+                    OidcVerificationOptions(
+                        jwksUri = FACEBOOK_JWK_URI,
+                        expectedIssuer = FACEBOOK_ISSUER,
+                        expectedAudience = facebookAppId,
+                    ),
+            ) ?: return null
+
+        return OAuth2UserResponse(
+            socialId = claims["sub"] as? String ?: return null,
+            name = claims["name"] as? String,
+            email = claims["email"] as? String,
+            isEmailVerified = claims["email_verified"] as? Boolean ?: true,
+        )
     }
 }

--- a/core/src/main/kotlin/auth/oidc/OidcJwk.kt
+++ b/core/src/main/kotlin/auth/oidc/OidcJwk.kt
@@ -1,6 +1,6 @@
-package com.wafflestudio.snutt.auth.apple
+package com.wafflestudio.snutt.auth.oidc
 
-data class AppleJwk(
+data class OidcJwk(
     val kty: String,
     val kid: String,
     val use: String,

--- a/core/src/main/kotlin/auth/oidc/OidcJwkSet.kt
+++ b/core/src/main/kotlin/auth/oidc/OidcJwkSet.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.snutt.auth.oidc
+
+data class OidcJwkSet(
+    val keys: List<OidcJwk>,
+)

--- a/core/src/main/kotlin/auth/oidc/OidcJwtVerifier.kt
+++ b/core/src/main/kotlin/auth/oidc/OidcJwtVerifier.kt
@@ -1,0 +1,147 @@
+package com.wafflestudio.snutt.auth.oidc
+
+import com.wafflestudio.snutt.common.extension.get
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import org.slf4j.LoggerFactory
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.time.Duration
+import java.util.Base64
+import java.util.Date
+
+data class OidcVerificationOptions(
+    val jwksUri: String,
+    val expectedIssuer: String? = null,
+    val expectedAudience: String? = null,
+)
+
+@Component
+@RegisterReflectionForBinding(
+    OidcJwkSet::class,
+    OidcJwk::class,
+)
+class OidcJwtVerifier(
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val webClient =
+        WebClient
+            .builder()
+            .clientConnector(
+                ReactorClientHttpConnector(
+                    HttpClient.create().responseTimeout(
+                        Duration.ofSeconds(3),
+                    ),
+                ),
+            ).build()
+
+    suspend fun verifyAndDecodeToken(
+        token: String,
+        options: OidcVerificationOptions,
+    ): Claims? =
+        runCatching {
+            val jwtHeader = extractJwtHeader(token) ?: return null
+            val oidcJwk = fetchJwk(jwtHeader, options.jwksUri) ?: return null
+            val publicKey = convertJwkToPublicKey(oidcJwk)
+            val claims = parseSignedClaims(token, publicKey)
+
+            if (!isValidIssuer(claims, options.expectedIssuer)) return null
+            if (!isValidAudience(claims, options.expectedAudience)) return null
+            if (!isNotExpired(claims)) return null
+
+            claims
+        }.onFailure {
+            log.warn("failed to verify oidc token {}: {}", token, it.message)
+        }.getOrNull()
+
+    fun looksLikeJwt(token: String): Boolean {
+        val parts = token.split(".")
+        return parts.size == 3 && parts.none { it.isBlank() }
+    }
+
+    private suspend fun fetchJwk(
+        jwtHeader: OidcJwtHeader,
+        jwksUri: String,
+    ): OidcJwk? =
+        webClient
+            .get<OidcJwkSet>(uri = jwksUri)
+            .getOrNull()
+            ?.keys
+            ?.find {
+                it.kid == jwtHeader.kid && (it.alg == jwtHeader.alg || it.alg.isBlank())
+            } ?: return null
+
+    private fun extractJwtHeader(token: String): OidcJwtHeader? {
+        if (!looksLikeJwt(token)) return null
+
+        val headerJson = Base64.getUrlDecoder().decode(token.substringBefore(".")).toString(Charsets.UTF_8)
+        val headerMap: Map<String, String?> = objectMapper.readValue(headerJson)
+        val kid = headerMap["kid"] ?: return null
+        val alg = headerMap["alg"] ?: return null
+
+        return OidcJwtHeader(
+            kid = kid,
+            alg = alg,
+        )
+    }
+
+    private fun convertJwkToPublicKey(jwk: OidcJwk): PublicKey {
+        if (jwk.kty != "RSA") throw IllegalArgumentException("unsupported kty: ${jwk.kty}")
+
+        val modulus = BigInteger(1, Base64.getUrlDecoder().decode(jwk.n))
+        val exponent = BigInteger(1, Base64.getUrlDecoder().decode(jwk.e))
+        val spec = RSAPublicKeySpec(modulus, exponent)
+        return KeyFactory.getInstance("RSA").generatePublic(spec)
+    }
+
+    private fun parseSignedClaims(
+        token: String,
+        publicKey: PublicKey,
+    ) = Jwts
+        .parser()
+        .verifyWith(publicKey)
+        .build()
+        .parseSignedClaims(token)
+        .payload
+
+    private fun isValidIssuer(
+        claims: Claims,
+        expectedIssuer: String?,
+    ): Boolean = expectedIssuer == null || (claims["iss"] as? String) == expectedIssuer
+
+    private fun isValidAudience(
+        claims: Claims,
+        expectedAudience: String?,
+    ): Boolean {
+        if (expectedAudience == null) return true
+
+        val audience = claims["aud"] ?: return false
+
+        return when (audience) {
+            is String -> audience == expectedAudience
+            is Collection<*> -> audience.any { it == expectedAudience }
+            else -> false
+        }
+    }
+
+    private fun isNotExpired(claims: Claims): Boolean {
+        val expiration = claims.expiration ?: return false
+        return expiration.after(Date())
+    }
+}
+
+private data class OidcJwtHeader(
+    val kid: String,
+    val alg: String,
+)

--- a/core/src/main/resources/application-common.yml
+++ b/core/src/main/resources/application-common.yml
@@ -29,6 +29,12 @@ google:
         bundle-id:
         app-store-id:
 
+oidc:
+  facebook:
+    app-id:
+  apple:
+    app-id:
+
 http:
   response-timeout: 3s
 

--- a/core/src/testFixtures/resources/application.yaml
+++ b/core/src/testFixtures/resources/application.yaml
@@ -23,6 +23,12 @@ google:
         bundle-id:
         app-store-id:
 
+oidc:
+  facebook:
+    app-id: test-facebook-app-id
+  apple:
+    app-id: test-apple-app-id
+
 http:
   responseTimeout: 3s
 


### PR DESCRIPTION
ios 페이스북 sdk가 limited login을 하면 oidc 방식의 토큰을 주는데, oidc 검증하는게 표준적인 거라 애플이랑 페이스북 둘 다 쓸수 있게 별도로 분리했습니다 (일단 RSA 방식만 대응)
페이스북 토큰은 이전 access token 방식이랑 authentication token (limited) 를 같은 엔드포인트에서 받도록 했습니다
애플 로그인에서 기존에 iss, aud 검증을 안하고 있었는데 하면서 같이 추가했고요
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1770820826270859