### PR TITLE
SwaggerConfig에 NumberType reflection hint 추가

### DIFF
--- a/api/src/main/kotlin/config/SwaggerConfig.kt
+++ b/api/src/main/kotlin/config/SwaggerConfig.kt
@@ -6,8 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import tools.jackson.core.JsonParser
 
 @OpenAPIDefinition(
     servers = [Server(url = "/", description = "Local")],
@@ -18,6 +20,7 @@ import org.springframework.context.annotation.Configuration
         ),
 )
 @Configuration
+@RegisterReflectionForBinding(JsonParser.NumberType::class)
 class SwaggerConfig {
     @Bean
     fun openApiCustomizer() =


### PR DESCRIPTION
```
2026-03-01T09:53:43.330Z  WARN 1 --- [ool-11-thread-1] o.s.c.utils.SpringDocAnnotationsUtils    : Graceful exception occurred
java.lang.UnsupportedOperationException: Type not found: class tools.jackson.core.JsonParser$NumberType
	at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaClassifierType.getClassifierQualifiedName(ReflectJavaClassifierType.kt:41)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.types.JavaTypeResolver.createNotFoundClass(JavaTypeResolver.kt:161)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.types.JavaTypeResolver.computeTypeConstructor(JavaTypeResolver.kt:147)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.types.JavaTypeResolver.computeSimpleJavaClassifierType(JavaTypeResolver.kt:128)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.types.JavaTypeResolver.transformJavaClassifierType(JavaTypeResolver.kt:108)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.types.JavaTypeResolver.transformJavaType(JavaTypeResolver.kt:58)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.computeMethodReturnType(LazyJavaScope.kt:201)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.resolveMethodToFunctionDescriptor(LazyJavaScope.kt:168)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.declaredFunctions$lambda$0(LazyJavaScope.kt:94)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda2(LazyJavaScope.kt)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$2.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:578)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:681)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.declaredFunctions$lambda$0(LazyJavaScope.kt:89)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda2(LazyJavaScope.kt)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$2.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:578)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:681)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.functions$lambda$0(LazyJavaScope.kt:119)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda4(LazyJavaScope.kt)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$4.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:578)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:681)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedFunctions(LazyJavaScope.kt:273)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getContributedFunctions(LazyJavaClassMemberScope.kt:865)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getFunctionsFromSupertypes(LazyJavaClassMemberScope.kt:490)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.computeNonDeclaredFunctions(LazyJavaClassMemberScope.kt:319)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.functions$lambda$0(LazyJavaScope.kt:123)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda4(LazyJavaScope.kt)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$4.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:578)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:681)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedFunctions(LazyJavaScope.kt:273)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getContributedFunctions(LazyJavaClassMemberScope.kt:865)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.computeDescriptors(LazyJavaScope.kt:378)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.allDescriptors$lambda$0(LazyJavaScope.kt:64)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda0(LazyJavaScope.kt)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$0.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
	at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedDescriptors(LazyJavaScope.kt:357)
	at kotlin.reflect.jvm.internal.impl.resolve.scopes.ResolutionScope$DefaultImpls.getContributedDescriptors$default(ResolutionScope.kt:50)
	at kotlin.reflect.jvm.internal.KClassImpl.getMembers(KClassImpl.kt:353)
	at kotlin.reflect.jvm.internal.KClassImpl.access$getMembers(KClassImpl.kt:62)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.declaredNonStaticMembers_delegate$lambda$0(KClassImpl.kt:302)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda12(KClassImpl.kt)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$12.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.getDeclaredNonStaticMembers(KClassImpl.kt:302)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.allNonStaticMembers_delegate$lambda$0(KClassImpl.kt:311)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda16(KClassImpl.kt)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$16.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.getAllNonStaticMembers(KClassImpl.kt:311)
	at kotlin.reflect.full.KClasses.getMemberProperties(KClasses.kt:150)
	at org.springdoc.core.customizers.KotlinDeprecatedPropertyCustomizer.resolve(KotlinDeprecatedPropertyCustomizer.kt:66)
	at org.springdoc.core.converters.KotlinInlineClassUnwrappingConverter.resolve(KotlinInlineClassUnwrappingConverter.kt:42)
	at org.springdoc.core.converters.PageableOpenAPIConverter.resolve(PageableOpenAPIConverter.java:97)
	at org.springdoc.core.converters.PageOpenAPIConverter.resolve(PageOpenAPIConverter.java:102)
	at org.springdoc.core.converters.SortOpenAPIConverter.resolve(SortOpenAPIConverter.java:92)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:819)
	at org.springdoc.core.converters.WebFluxSupportConverter.resolve(WebFluxSupportConverter.java:89)
	at org.springdoc.core.converters.AdditionalModelsConverter.resolve(AdditionalModelsConverter.java:176)
	at org.springdoc.core.converters.FileSupportConverter.resolve(FileSupportConverter.java:72)
	at org.springdoc.core.converters.ResponseSupportConverter.resolve(ResponseSupportConverter.java:87)
	at org.springdoc.core.converters.SchemaPropertyDeprecatingConverter.resolve(SchemaPropertyDeprecatingConverter.java:95)
	at org.springdoc.core.converters.PolymorphicModelConverter.resolve(PolymorphicModelConverter.java:173)
	at org.springdoc.core.customizers.KotlinDeprecatedPropertyCustomizer.resolve(KotlinDeprecatedPropertyCustomizer.kt:55)
	at org.springdoc.core.converters.KotlinInlineClassUnwrappingConverter.resolve(KotlinInlineClassUnwrappingConverter.kt:42)
	at org.springdoc.core.converters.PageableOpenAPIConverter.resolve(PageableOpenAPIConverter.java:97)
	at org.springdoc.core.converters.PageOpenAPIConverter.resolve(PageOpenAPIConverter.java:102)
	at org.springdoc.core.converters.SortOpenAPIConverter.resolve(SortOpenAPIConverter.java:92)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at org.springdoc.core.utils.SpringDocAnnotationsUtils.resolveAsResolvedSchema(SpringDocAnnotationsUtils.java:545)
	at org.springdoc.core.utils.SpringDocAnnotationsUtils.extractSchema(SpringDocAnnotationsUtils.java:151)
	at org.springdoc.core.service.GenericParameterService.calculateSchema(GenericParameterService.java:410)
	at org.springdoc.core.service.RequestBodyService.buildRequestBody(RequestBodyService.java:299)
	at org.springdoc.core.service.RequestBodyService.calculateRequestBodyInfo(RequestBodyService.java:272)
	at org.springdoc.core.service.AbstractRequestService.build(AbstractRequestService.java:385)
	at org.springdoc.api.AbstractOpenApiResource.calculatePath(AbstractOpenApiResource.java:662)
	at org.springdoc.api.AbstractOpenApiResource.calculatePath(AbstractOpenApiResource.java:871)
	at org.springdoc.webflux.api.OpenApiResource.lambda$calculatePath$5(OpenApiResource.java:201)
	at java.base@25.0.1/java.util.Optional.ifPresent(Optional.java:178)
	at org.springdoc.webflux.api.OpenApiResource.calculatePath(OpenApiResource.java:179)
	at org.springdoc.webflux.api.OpenApiResource.lambda$getPaths$0(OpenApiResource.java:162)
	at java.base@25.0.1/java.util.Optional.ifPresent(Optional.java:178)
	at org.springdoc.webflux.api.OpenApiResource.getPaths(OpenApiResource.java:154)
	at org.springdoc.api.AbstractOpenApiResource.getOpenApi(AbstractOpenApiResource.java:403)
	at org.springdoc.api.AbstractOpenApiResource.lambda$new$1(AbstractOpenApiResource.java:276)
	at java.base@25.0.1/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base@25.0.1/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base@25.0.1/java.lang.Thread.runWith(Thread.java:1487)
	at java.base@25.0.1/java.lang.Thread.run(Thread.java:1474)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
```
이거 해결용이에요