### PR TITLE
비밀번호 초기화 시 localId로 사용자 찾도록 수정

### DIFF
--- a/api/src/main/kotlin/controller/AuthController.kt
+++ b/api/src/main/kotlin/controller/AuthController.kt
@@ -92,7 +92,7 @@ class AuthController(
     suspend fun verifyResetPasswordCode(
         @RequestBody body: VerificationCodeRequest,
     ): OkResponse {
-        val user = userService.getUser(body.userId!!)
+        val user = userService.getUserByLocalId(body.userId!!)
         userService.verifyResetPasswordCode(user, body.code)
         return OkResponse()
     }

--- a/api/src/main/kotlin/controller/AuthController.kt
+++ b/api/src/main/kotlin/controller/AuthController.kt
@@ -92,7 +92,7 @@ class AuthController(
     suspend fun verifyResetPasswordCode(
         @RequestBody body: VerificationCodeRequest,
     ): OkResponse {
-        val user = userService.getUserByLocalId(body.userId!!)
+        val user = userService.getUserByLocalId(body.localId!!)
         userService.verifyResetPasswordCode(user, body.code)
         return OkResponse()
     }

--- a/core/src/main/kotlin/users/dto/VerificationCodeRequest.kt
+++ b/core/src/main/kotlin/users/dto/VerificationCodeRequest.kt
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class VerificationCodeRequest(
     @param:JsonProperty("user_id")
-    val userId: String? = null,
+    val localId: String? = null,
     val code: String,
 )

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -581,7 +581,7 @@ class UserServiceImpl(
     }
 
     override suspend fun getMaskedEmail(localId: String): String {
-        val user = userRepository.findByCredentialLocalIdAndActiveTrue(localId) ?: throw UserNotFoundException
+        val user = getUserByLocalId(localId)
         val email = user.email ?: throw UserNotFoundException
         val maskedEmail = email.replace(emailMaskRegex, "*")
         return maskedEmail
@@ -592,7 +592,7 @@ class UserServiceImpl(
         newPassword: String,
         code: String,
     ) {
-        val user = userRepository.findByCredentialLocalIdAndActiveTrue(localId) ?: throw UserNotFoundException
+        val user = getUserByLocalId(localId)
         verifyResetPasswordCode(user, code)
         if (!authService.isValidPassword(newPassword)) throw InvalidPasswordException
         user.apply {

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -52,6 +52,8 @@ import kotlin.random.Random
 interface UserService {
     suspend fun getUser(userId: String): User
 
+    suspend fun getUserByLocalId(localId: String): User
+
     suspend fun getUsers(userIds: List<String>): List<User>
 
     suspend fun patchUserInfo(
@@ -147,6 +149,9 @@ class UserServiceImpl(
     private val log = LoggerFactory.getLogger(javaClass)
 
     override suspend fun getUser(userId: String): User = userRepository.findByIdAndActiveTrue(userId) ?: throw UserNotFoundException
+
+    override suspend fun getUserByLocalId(localId: String): User =
+        userRepository.findByCredentialLocalIdAndActiveTrue(localId) ?: throw UserNotFoundException
 
     override suspend fun getUsers(userIds: List<String>): List<User> = userRepository.findAllByIdInAndActiveTrue(userIds)
 


### PR DESCRIPTION
db 안의 id로 찾고있었음...
https://github.com/wafflestudio/snutt/pull/490 가 원인이었고
api에는 user_id 로 보이긴하는데 서버에서 헷갈릴 일을 줄이기 위해 localId로 필드명 바꿨습니다