### PR TITLE
강의 정보 영어 지원 추가

### DIFF
--- a/api/src/main/kotlin/controller/BookmarkController.kt
+++ b/api/src/main/kotlin/controller/BookmarkController.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.controller
 import com.wafflestudio.snutt.bookmark.dto.BookmarkLectureModifyRequest
 import com.wafflestudio.snutt.bookmark.dto.BookmarkResponse
 import com.wafflestudio.snutt.bookmark.service.BookmarkService
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.dto.ExistenceResponse
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.config.CurrentUser
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -33,10 +35,12 @@ class BookmarkController(
         @CurrentUser user: User,
         @RequestParam year: Int,
         @RequestParam semester: Semester,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ): BookmarkResponse {
         val userId = user.id!!
         val bookmark = bookmarkService.getBookmark(userId, year, semester)
-        val bookmarkLectureDtos = bookmarkService.convertBookmarkLecturesToBookmarkLectureDtos(bookmark.lectures)
+        val bookmarkLectureDtos =
+            bookmarkService.convertBookmarkLecturesToBookmarkLectureDtos(bookmark.lectures, clientInfo.language)
 
         return BookmarkResponse(
             year = bookmark.year,

--- a/api/src/main/kotlin/controller/FriendTableController.kt
+++ b/api/src/main/kotlin/controller/FriendTableController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.controller
 
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.common.exception.FriendNotFoundException
 import com.wafflestudio.snutt.config.CurrentUser
@@ -12,6 +13,7 @@ import com.wafflestudio.snutt.users.data.User
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -33,6 +35,7 @@ class FriendTableController(
         @PathVariable friendId: String,
         @RequestParam semester: Semester,
         @RequestParam year: Int,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ): TimetableDto {
         val userId = user.id!!
         val friend =
@@ -43,7 +46,7 @@ class FriendTableController(
 
         return timetableService
             .getUserPrimaryTable(friend.getPartnerUserId(userId), year, semester)
-            .let(::TimetableDto)
+            .let { TimetableDto(it, clientInfo.language) }
     }
 
     @GetMapping("/coursebooks")

--- a/api/src/main/kotlin/controller/LectureSearchController.kt
+++ b/api/src/main/kotlin/controller/LectureSearchController.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snutt.controller
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.ClientInfo
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.filter.SnuttNoAuthApiFilterTarget
 import com.wafflestudio.snutt.lectures.dto.SearchDto
@@ -9,6 +11,7 @@ import com.wafflestudio.snutt.lectures.service.LectureService
 import kotlinx.coroutines.flow.toList
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -26,8 +29,9 @@ class LectureSearchController(
     @PostMapping("")
     suspend fun searchLectures(
         @RequestBody query: SearchQueryLegacy,
-    ) = lectureService.search(query.toSearchDto()).toList().let {
-        lectureService.convertLecturesToLectureDtos(it)
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
+    ) = lectureService.search(query.toSearchDto(clientInfo.language)).toList().let {
+        lectureService.convertLecturesToLectureDtos(it, clientInfo.language)
     }
 }
 
@@ -52,10 +56,11 @@ data class SearchQueryLegacy(
     val sortCriteria: String? = null,
     val categoryPre2025: List<String>? = null,
 ) {
-    fun toSearchDto(): SearchDto =
+    fun toSearchDto(language: Language = Language.KO): SearchDto =
         SearchDto(
             year = year,
             semester = semester,
+            language = language,
             query = title,
             classification = classification,
             credit = credit,

--- a/api/src/main/kotlin/controller/TagController.kt
+++ b/api/src/main/kotlin/controller/TagController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.controller
 
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.filter.SnuttDefaultApiFilterTarget
 import com.wafflestudio.snutt.tag.TagListService
@@ -8,6 +9,7 @@ import com.wafflestudio.snutt.tag.data.TagListUpdateTimeResponse
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -25,9 +27,10 @@ class TagController(
     suspend fun getTagList(
         @PathVariable year: Int,
         @PathVariable semester: Semester,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ): TagListResponse {
         val tagList = tagService.getTagList(year, semester)
-        return TagListResponse(tagList)
+        return TagListResponse(tagList, clientInfo.language)
     }
 
     @GetMapping("/{year}/{semester}/update_time")

--- a/api/src/main/kotlin/controller/TimetableController.kt
+++ b/api/src/main/kotlin/controller/TimetableController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.controller
 
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.config.CurrentUser
 import com.wafflestudio.snutt.filter.SnuttDefaultApiFilterTarget
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -39,22 +41,24 @@ class TimetableController(
     @GetMapping("/recent")
     suspend fun getMostRecentlyUpdatedTimetables(
         @CurrentUser user: User,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableService
         .getMostRecentlyUpdatedTimetable(user.id!!)
-        .let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        .let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @GetMapping("/{year}/{semester}")
     suspend fun getTimetablesBySemester(
         @CurrentUser user: User,
         @PathVariable year: Int,
         @PathVariable semester: Semester,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableService
         .getTimetablesBySemester(
             user.id!!,
             year,
             semester,
         ).toList()
-        .map { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        .map { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @PostMapping("")
     suspend fun addTimetable(
@@ -75,9 +79,10 @@ class TimetableController(
     suspend fun getTimetable(
         @CurrentUser user: User,
         @PathVariable timetableId: String,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableService
         .getTimetable(user.id!!, timetableId)
-        .let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        .let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @PutMapping("/{timetableId}")
     suspend fun modifyTimetable(
@@ -115,9 +120,10 @@ class TimetableController(
         @CurrentUser user: User,
         @PathVariable timetableId: String,
         @RequestBody body: TimetableModifyThemeRequestDto,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableService
         .modifyTimetableTheme(user.id!!, timetableId, body.theme, body.themeId)
-        .let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        .let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @PostMapping("/{timetableId}/primary")
     suspend fun setPrimary(

--- a/api/src/main/kotlin/controller/TimetableLectureController.kt
+++ b/api/src/main/kotlin/controller/TimetableLectureController.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt.controller
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.config.CurrentUser
 import com.wafflestudio.snutt.filter.SnuttDefaultApiFilterTarget
 import com.wafflestudio.snutt.timetables.dto.request.CustomTimetableLectureAddLegacyRequestDto
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -35,13 +37,14 @@ class TimetableLectureController(
         @PathVariable timetableId: String,
         @RequestParam(required = false) isForced: Boolean?,
         @RequestBody customTimetable: CustomTimetableLectureAddLegacyRequestDto,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableLectureService
         .addCustomTimetableLecture(
             userId = user.id!!,
             timetableId = timetableId,
             timetableLectureRequest = customTimetable,
             isForced = isForced ?: customTimetable.isForced,
-        ).let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        ).let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @PostMapping("/{lectureId}")
     suspend fun addLecture(
@@ -50,13 +53,14 @@ class TimetableLectureController(
         @PathVariable lectureId: String,
         @RequestParam(required = false) isForced: Boolean?,
         @RequestBody(required = false) body: ForcedReq?,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableLectureService
         .addLecture(
             userId = user.id!!,
             timetableId = timetableId,
             lectureId = lectureId,
             isForced = isForced ?: body?.isForced ?: false,
-        ).let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        ).let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @PutMapping("/{timetableLectureId}/reset")
     suspend fun resetTimetableLecture(
@@ -65,13 +69,14 @@ class TimetableLectureController(
         @PathVariable timetableLectureId: String,
         @RequestParam(required = false) isForced: Boolean?,
         @RequestBody(required = false) body: ForcedReq?,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableLectureService
         .resetTimetableLecture(
             userId = user.id!!,
             timetableId = timetableId,
             timetableLectureId = timetableLectureId,
             isForced = isForced ?: body?.isForced ?: false,
-        ).let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        ).let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @PutMapping("/{timetableLectureId}")
     suspend fun modifyTimetableLecture(
@@ -80,6 +85,7 @@ class TimetableLectureController(
         @PathVariable timetableLectureId: String,
         @RequestParam(required = false) isForced: Boolean?,
         @RequestBody modifyRequestDto: TimetableLectureModifyLegacyRequestDto,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableLectureService
         .modifyTimetableLecture(
             userId = user.id!!,
@@ -87,19 +93,20 @@ class TimetableLectureController(
             timetableLectureId = timetableLectureId,
             modifyTimetableLectureRequestDto = modifyRequestDto,
             isForced = isForced ?: modifyRequestDto.isForced,
-        ).let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        ).let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     @DeleteMapping("/{timetableLectureId}")
     suspend fun deleteTimetableLecture(
         @CurrentUser user: User,
         @PathVariable timetableId: String,
         @PathVariable timetableLectureId: String,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = timetableLectureService
         .deleteTimetableLecture(
             userId = user.id!!,
             timetableId = timetableId,
             timetableLectureId = timetableLectureId,
-        ).let { timetableService.convertTimetableToTimetableLegacyDto(it) }
+        ).let { timetableService.convertTimetableToTimetableLegacyDto(it, clientInfo.language) }
 
     data class ForcedReq(
         @param:JsonProperty("is_forced")

--- a/api/src/main/kotlin/controller/VacancyNotificationController.kt
+++ b/api/src/main/kotlin/controller/VacancyNotificationController.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.controller
 
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.dto.ExistenceResponse
 import com.wafflestudio.snutt.config.CurrentUser
 import com.wafflestudio.snutt.filter.SnuttDefaultApiFilterTarget
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -29,9 +31,10 @@ class VacancyNotificationController(
     @GetMapping("/lectures")
     suspend fun getVacancyNotificationLectures(
         @CurrentUser user: User,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
     ) = vacancyNotificationService
         .getVacancyNotificationLectures(user.id!!)
-        .let { lectureService.convertLecturesToLectureDtos(it) }
+        .let { lectureService.convertLecturesToLectureDtos(it, clientInfo.language) }
         .let { VacancyNotificationLecturesResponse(it) }
 
     @GetMapping("/lectures/{lectureId}/state")

--- a/api/src/main/kotlin/filter/ClientInfoWebFilter.kt
+++ b/api/src/main/kotlin/filter/ClientInfoWebFilter.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.filter
 import com.wafflestudio.snutt.common.client.AppType
 import com.wafflestudio.snutt.common.client.AppVersion
 import com.wafflestudio.snutt.common.client.ClientInfo
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.client.OsType
 import com.wafflestudio.snutt.common.exception.InvalidAppTypeException
 import com.wafflestudio.snutt.common.exception.InvalidOsTypeException
@@ -46,6 +47,7 @@ class ClientInfoWebFilter(
                             appVersion = headers.getFirst("x-app-version")?.let { AppVersion(it) },
                             deviceId = headers.getFirst("x-device-id"),
                             deviceModel = headers.getFirst("x-device-model"),
+                            language = Language.from(headers.getFirst("x-language")) ?: Language.KO,
                         )
                     exchange.attributes[CLIENT_INFO_ATTRIBUTE_KEY] = clientInfo
                 }

--- a/batch/src/main/kotlin/sugangsnu/common/data/SugangSnuLectureInfo.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/data/SugangSnuLectureInfo.kt
@@ -85,7 +85,7 @@ data class SugangSnuLectureSubInfo(
     // 영문 비고
     @param:JsonProperty("openLtEngRemk")
     val remarkEng: String? = null,
-    // 영문 이수과정 (Bachelor / Master's / Doctorate / Combined Master's/Doctorate)
+    // 영문 이수과정 (Bachelor / Master's / Doctorate / Combined Masters/Doctorate)
     @param:JsonProperty("cptnCorsFgEngNm")
     val academicCourseEng: String? = null,
 //    @param:JsonProperty("frnStdTlsnLmtYn")

--- a/batch/src/main/kotlin/sugangsnu/common/data/SugangSnuLectureInfo.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/data/SugangSnuLectureInfo.kt
@@ -70,8 +70,24 @@ data class SugangSnuLectureSubInfo(
     // 비고
     @param:JsonProperty("openLtRemk")
     val remark: String? = null,
-//    @param:JsonProperty("openLtEngRemk")
-//    val openLtEngRemk: String? = null,
+    // 영문 강의명
+    @param:JsonProperty("sbjtEngNm")
+    val courseNameEng: String? = null,
+    // 영문 부제
+    @param:JsonProperty("sbjtSubhEngNm")
+    val courseSubNameEng: String? = null,
+    // 영문 교수
+    @param:JsonProperty("profEngNm")
+    val professorNameEng: String? = null,
+    // 영문 분야
+    @param:JsonProperty("sbjtFldEngNm")
+    val categoryEng: String? = null,
+    // 영문 비고
+    @param:JsonProperty("openLtEngRemk")
+    val remarkEng: String? = null,
+    // 영문 이수과정 (Bachelor / Master's / Doctorate / Combined Master's/Doctorate)
+    @param:JsonProperty("cptnCorsFgEngNm")
+    val academicCourseEng: String? = null,
 //    @param:JsonProperty("frnStdTlsnLmtYn")
 //    val frnStdTlsnLmtYn: String? = null,
 //    @param:JsonProperty("mrksGvMthd")

--- a/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuFetchService.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuFetchService.kt
@@ -71,6 +71,19 @@ class SugangSnuFetchServiceImpl(
                         null
                     }
 
+                val extraCourseTitleEn =
+                    if (extraLectureInfo.subInfo.courseSubNameEng.isNullOrEmpty()) {
+                        extraLectureInfo.subInfo.courseNameEng
+                    } else {
+                        "${extraLectureInfo.subInfo.courseNameEng} (${extraLectureInfo.subInfo.courseSubNameEng})"
+                    }
+                val extraDepartmentEn =
+                    if (extraLectureInfo.subInfo.departmentEngNm != null && extraLectureInfo.subInfo.majorEngNm != null) {
+                        "${extraLectureInfo.subInfo.departmentEngNm}(${extraLectureInfo.subInfo.majorEngNm})"
+                    } else {
+                        null
+                    }
+
                 lecture.apply {
                     classPlaceAndTimes =
                         SugangSnuClassTimeUtils.convertTextToClassTimeObject(
@@ -86,6 +99,13 @@ class SugangSnuFetchServiceImpl(
                     quota = extraLectureInfo.subInfo.quota ?: quota
                     remark = extraLectureInfo.subInfo.remark ?: remark
                     categoryPre2025 = courseNumberCategoryPre2025Map[lecture.courseNumber]
+                    academicYearEn = extraLectureInfo.subInfo.academicCourseEng.takeIf { it != "Bachelor" }
+                        ?: extraLectureInfo.subInfo.academicYear?.let { "Year $it" } ?: academicYearEn
+                    courseTitleEn = extraCourseTitleEn ?: courseTitleEn
+                    instructorEn = (extraLectureInfo.subInfo.professorNameEng ?: instructorEn)?.substringBeforeLast(" (")
+                    categoryEn = extraLectureInfo.subInfo.categoryEng ?: categoryEn
+                    departmentEn = extraDepartmentEn ?: departmentEn
+                    remarkEn = extraLectureInfo.subInfo.remarkEng ?: remarkEn
                 }
             }
     }
@@ -131,10 +151,22 @@ class SugangSnuFetchServiceImpl(
         val remark = row.getCellByColumnName("비고")
         val registrationCount = row.getCellByColumnName("수강신청인원").toIntOrNull() ?: 0
 
+        // 영문 컬럼 (한글 컬럼과 zip으로 합쳐진 영문 엑셀 헤더). KO 파생 로직을 1:1 미러.
+        val classificationEn = row.getCellByColumnName("Course Classification")
+        val collegeEn = row.getCellByColumnName("College")
+        val departmentEn = row.getCellByColumnName("Department")
+        val academicCourseEn = row.getCellByColumnName("Degree Program")
+        val academicYearEn = row.getCellByColumnName("Academic Year")
+        val courseTitleEn = row.getCellByColumnName("Course Title")
+        val courseSubtitleEn = row.getCellByColumnName("Course Subtitle")
+        val instructorEn = row.getCellByColumnName("Instructor")
+        val remarkEn = row.getCellByColumnName("Remark")
+
         val classTimes =
             SugangSnuClassTimeUtils.convertTextToClassTimeObject(classTimeText.split("/"), location.split("/"))
 
         val courseFullTitle = if (courseSubtitle.isEmpty()) courseTitle else "$courseTitle ($courseSubtitle)"
+        val courseFullTitleEn = if (courseSubtitleEn.isEmpty()) courseTitleEn else "$courseTitleEn ($courseSubtitleEn)"
 
         return Lecture(
             classification = classification,
@@ -155,6 +187,14 @@ class SugangSnuFetchServiceImpl(
             classPlaceAndTimes = classTimes,
             registrationCount = registrationCount,
             categoryPre2025 = null,
+            // 분야(category)는 엑셀 컬럼이 없어 KO와 동일하게 비움. 나머지는 KO 파생 로직 미러.
+            classificationEn = classificationEn,
+            departmentEn = departmentEn.replace("null", "").ifEmpty { collegeEn },
+            academicYearEn = academicCourseEn.takeIf { it != "Bachelor" } ?: academicYearEn,
+            courseTitleEn = courseFullTitleEn,
+            instructorEn = instructorEn,
+            categoryEn = "",
+            remarkEn = remarkEn,
         )
     }
 }

--- a/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuFetchService.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuFetchService.kt
@@ -43,14 +43,32 @@ class SugangSnuFetchServiceImpl(
     ): List<Lecture> {
         val koreanLectureXlsx = sugangSnuRepository.getSugangSnuLectures(year, semester, "ko")
         val englishLectureXlsx = sugangSnuRepository.getSugangSnuLectures(year, semester, "en")
-        val koreanSheet = HSSFWorkbook(koreanLectureXlsx.asInputStream()).getSheetAt(0)
-        val englishSheet = HSSFWorkbook(englishLectureXlsx.asInputStream()).getSheetAt(0)
-        val fullSheet = koreanSheet.zip(englishSheet).map { (koreanRow, englishRow) -> koreanRow + englishRow }
-        val columnNameIndex = fullSheet[2].associate { it.stringCellValue to it.columnIndex }
-        return fullSheet
+        val koreanRows = HSSFWorkbook(koreanLectureXlsx.asInputStream()).getSheetAt(0).map { it.toList() }
+        val englishRows = HSSFWorkbook(englishLectureXlsx.asInputStream()).getSheetAt(0).map { it.toList() }
+        val koreanColumnIndex = koreanRows[2].associate { it.stringCellValue to it.columnIndex }
+        val englishColumnIndex = englishRows[2].associate { it.stringCellValue to it.columnIndex }
+
+        // 한/영 엑셀은 행 순서가 어긋날 수 있어 인덱스(zip) 결합 대신 (교과목번호, 강좌번호) 키로 조인한다.
+        // 키가 없는 강의는 englishRow == null 이 되어 _en 필드가 null → 읽기 시점 KO 폴백으로 자연 수렴한다.
+        val englishRowByKey =
+            englishRows.drop(3).associateBy {
+                it.getCellByColumnName(englishColumnIndex, "Course Number") to
+                    it.getCellByColumnName(englishColumnIndex, "Lecture Number")
+            }
+        return koreanRows
             .drop(3)
-            .map { row ->
-                convertSugangSnuRowToLecture(row, columnNameIndex, year, semester)
+            .map { koreanRow ->
+                val key =
+                    koreanRow.getCellByColumnName(koreanColumnIndex, "교과목번호") to
+                        koreanRow.getCellByColumnName(koreanColumnIndex, "강좌번호")
+                convertSugangSnuRowToLecture(
+                    koreanRow,
+                    koreanColumnIndex,
+                    englishRowByKey[key],
+                    englishColumnIndex,
+                    year,
+                    semester,
+                )
             }.also {
                 koreanLectureXlsx.release()
                 englishLectureXlsx.release()
@@ -100,9 +118,11 @@ class SugangSnuFetchServiceImpl(
                     remark = extraLectureInfo.subInfo.remark ?: remark
                     categoryPre2025 = courseNumberCategoryPre2025Map[lecture.courseNumber]
                     academicYearEn = extraLectureInfo.subInfo.academicCourseEng.takeIf { it != "Bachelor" }
-                        ?: extraLectureInfo.subInfo.academicYear?.let { "Year $it" } ?: academicYearEn
+                        ?: extraLectureInfo.subInfo.academicYear?.takeIf { it.isNotBlank() } ?: academicYearEn
                     courseTitleEn = extraCourseTitleEn ?: courseTitleEn
-                    instructorEn = (extraLectureInfo.subInfo.professorNameEng ?: instructorEn)?.substringBeforeLast(" (")
+                    instructorEn = extraLectureInfo.subInfo.professorNameEng
+                        ?.substringBeforeLast(" (")
+                        ?.takeIf { it.isNotBlank() } ?: instructorEn
                     categoryEn = extraLectureInfo.subInfo.categoryEng ?: categoryEn
                     departmentEn = extraDepartmentEn ?: departmentEn
                     remarkEn = extraLectureInfo.subInfo.remarkEng ?: remarkEn
@@ -115,58 +135,64 @@ class SugangSnuFetchServiceImpl(
     부제명, 학점, 강의, 실습, 수업교시, 수업형태, 강의실(동-호)(#연건, *평창), 주담당교수,
     장바구니신청, 신입생장바구니신청, 재학생장바구니신청, 정원, 수강신청인원, 비고, 강의언어, 개설상태,
      */
-    private fun convertSugangSnuRowToLecture(
-        row: List<Cell>,
+    private fun List<Cell>.getCellByColumnName(
         columnNameIndex: Map<String, Int>,
+        key: String,
+    ): String =
+        this[
+            columnNameIndex.getOrElse(key) {
+                log.error("$key 와 매칭되는 excel 컬럼이 존재하지 않습니다.")
+                this.size
+            },
+        ].stringCellValue
+
+    private fun convertSugangSnuRowToLecture(
+        koreanRow: List<Cell>,
+        koreanColumnIndex: Map<String, Int>,
+        englishRow: List<Cell>?,
+        englishColumnIndex: Map<String, Int>,
         year: Int,
         semester: Semester,
     ): Lecture {
-        fun List<Cell>.getCellByColumnName(key: String): String =
-            this[
-                columnNameIndex.getOrElse(key) {
-                    log.error("$key 와 매칭되는 excel 컬럼이 존재하지 않습니다.")
-                    this.size
-                },
-            ].stringCellValue
+        fun List<Cell>.ko(key: String) = getCellByColumnName(koreanColumnIndex, key)
 
-        val classification = row.getCellByColumnName("교과구분")
-        val college = row.getCellByColumnName("개설대학")
-        val department = row.getCellByColumnName("개설학과")
-        val academicCourse = row.getCellByColumnName("이수과정")
-        val academicYear = row.getCellByColumnName("학년")
-        val courseNumber = row.getCellByColumnName("교과목번호")
-        val lectureNumber = row.getCellByColumnName("강좌번호")
-        val courseTitle = row.getCellByColumnName("교과목명")
-        val courseSubtitle = row.getCellByColumnName("부제명")
-        val credit = row.getCellByColumnName("학점").toLong()
-        val classTimeText = row.getCellByColumnName("수업교시")
-        val location = row.getCellByColumnName("강의실(동-호)(#연건, *평창)")
-        val instructor = row.getCellByColumnName("주담당교수")
+        fun List<Cell>.en(key: String) = getCellByColumnName(englishColumnIndex, key)
+
+        val classification = koreanRow.ko("교과구분")
+        val college = koreanRow.ko("개설대학")
+        val department = koreanRow.ko("개설학과")
+        val academicCourse = koreanRow.ko("이수과정")
+        val academicYear = koreanRow.ko("학년")
+        val courseNumber = koreanRow.ko("교과목번호")
+        val lectureNumber = koreanRow.ko("강좌번호")
+        val courseTitle = koreanRow.ko("교과목명")
+        val courseSubtitle = koreanRow.ko("부제명")
+        val credit = koreanRow.ko("학점").toLong()
+        val classTimeText = koreanRow.ko("수업교시")
+        val location = koreanRow.ko("강의실(동-호)(#연건, *평창)")
+        val instructor = koreanRow.ko("주담당교수")
         val (quota, quotaForCurrentStudent) =
-            row
-                .getCellByColumnName("정원")
+            koreanRow
+                .ko("정원")
                 .takeIf { quotaRegex.matches(it) }
                 ?.let { quotaRegex.find(it)!!.groups }
                 ?.let { it["quota"]!!.value.toInt() to (it["quotaForCurrentStudent"]?.value?.toInt() ?: 0) } ?: (0 to 0)
-        val remark = row.getCellByColumnName("비고")
-        val registrationCount = row.getCellByColumnName("수강신청인원").toIntOrNull() ?: 0
-
-        // 영문 컬럼 (한글 컬럼과 zip으로 합쳐진 영문 엑셀 헤더). KO 파생 로직을 1:1 미러.
-        val classificationEn = row.getCellByColumnName("Course Classification")
-        val collegeEn = row.getCellByColumnName("College")
-        val departmentEn = row.getCellByColumnName("Department")
-        val academicCourseEn = row.getCellByColumnName("Degree Program")
-        val academicYearEn = row.getCellByColumnName("Academic Year")
-        val courseTitleEn = row.getCellByColumnName("Course Title")
-        val courseSubtitleEn = row.getCellByColumnName("Course Subtitle")
-        val instructorEn = row.getCellByColumnName("Instructor")
-        val remarkEn = row.getCellByColumnName("Remark")
+        val remark = koreanRow.ko("비고")
+        val registrationCount = koreanRow.ko("수강신청인원").toIntOrNull() ?: 0
 
         val classTimes =
             SugangSnuClassTimeUtils.convertTextToClassTimeObject(classTimeText.split("/"), location.split("/"))
 
         val courseFullTitle = if (courseSubtitle.isEmpty()) courseTitle else "$courseTitle ($courseSubtitle)"
-        val courseFullTitleEn = if (courseSubtitleEn.isEmpty()) courseTitleEn else "$courseTitleEn ($courseSubtitleEn)"
+
+        // 영문 엑셀 행은 (교과목번호, 강좌번호) 키로 조인된 것. 없으면 englishRow == null → _en 전부 null.
+        // KO 파생 로직을 1:1 미러. 분야(category)는 엑셀 컬럼이 없어 KO와 동일하게 비움.
+        val courseFullTitleEn =
+            englishRow?.let {
+                val courseTitleEn = it.en("Course Title")
+                val courseSubtitleEn = it.en("Course Subtitle")
+                if (courseSubtitleEn.isEmpty()) courseTitleEn else "$courseTitleEn ($courseSubtitleEn)"
+            }
 
         return Lecture(
             classification = classification,
@@ -187,14 +213,13 @@ class SugangSnuFetchServiceImpl(
             classPlaceAndTimes = classTimes,
             registrationCount = registrationCount,
             categoryPre2025 = null,
-            // 분야(category)는 엑셀 컬럼이 없어 KO와 동일하게 비움. 나머지는 KO 파생 로직 미러.
-            classificationEn = classificationEn,
-            departmentEn = departmentEn.replace("null", "").ifEmpty { collegeEn },
-            academicYearEn = academicCourseEn.takeIf { it != "Bachelor" } ?: academicYearEn,
+            classificationEn = englishRow?.en("Course Classification"),
+            departmentEn = englishRow?.let { it.en("Department").replace("null", "").ifEmpty { it.en("College") } },
+            academicYearEn = englishRow?.let { it.en("Degree Program").takeIf { dp -> dp != "Bachelor" } ?: it.en("Academic Year") },
             courseTitleEn = courseFullTitleEn,
-            instructorEn = instructorEn,
+            instructorEn = englishRow?.en("Instructor"),
             categoryEn = "",
-            remarkEn = remarkEn,
+            remarkEn = englishRow?.en("Remark"),
         )
     }
 }

--- a/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuNotificationService.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuNotificationService.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.sugangsnu.common.service
 import com.wafflestudio.snutt.common.push.DeeplinkType
 import com.wafflestudio.snutt.common.push.dto.PushMessage
 import com.wafflestudio.snutt.coursebook.data.Coursebook
+import com.wafflestudio.snutt.lectures.data.Lecture
 import com.wafflestudio.snutt.notification.data.Notification
 import com.wafflestudio.snutt.notification.data.NotificationType
 import com.wafflestudio.snutt.notification.data.PushPreferenceType
@@ -32,12 +33,34 @@ class SugangSnuNotificationServiceImpl(
     private val notificationService: NotificationService,
     private val pushService: PushService,
 ) : SugangSnuNotificationService {
+    // equalsMetadata 에 없어 단독으로는 변경 판정을 만들지 못하는 필드들.
+    // 빈자리 알림 job이 수시로 갱신하므로 _en 변경에 섞여 들어와 아래 억제 판정을 무너뜨리지 않도록 함께 무시한다.
+    private val nonNotifyingFieldNames = setOf(Lecture::registrationCount.name, Lecture::wasFull.name)
+
     override suspend fun notifyUserLectureChanges(userLectureSyncResults: List<UserLectureSyncResult>): Unit =
         coroutineScope {
-            val notifications = userLectureSyncResults.map { it.toNotification() }
+            // 스냅샷 동기화(_en 복사)는 sync 단계에서 이미 반영됐다. 여기서는 알릴 만한 변경이 없는 업데이트를
+            // 알림/푸시 대상에서 제외한다. (영문 데이터 최초 채움 sync에서 전 유저 대량 알림 방지)
+            val notifiableResults = userLectureSyncResults.filter { it.isNotifiable() }
+            val notifications = notifiableResults.map { it.toNotification() }
             notificationService.sendNotifications(notifications)
-            sendPushForTimetable(userLectureSyncResults.filterIsInstance<TimetableLectureSyncResult>())
+            sendPushForTimetable(notifiableResults.filterIsInstance<TimetableLectureSyncResult>())
         }
+
+    /**
+     * 한국어 알림 문구로 의미가 있는 변경이 하나라도 있으면 발송 대상.
+     * 영문(_en) 필드와 nonNotifyingFieldNames 만 바뀐 경우는 제외한다.
+     * 폐강 등 업데이트가 아닌 결과는 항상 발송한다.
+     */
+    private fun UserLectureSyncResult.isNotifiable(): Boolean {
+        val updatedFields =
+            when (this) {
+                is TimetableLectureUpdateResult -> updatedFields
+                is BookmarkLectureUpdateResult -> updatedFields
+                else -> return true
+            }
+        return updatedFields.any { it.name !in nonNotifyingFieldNames && !it.name.endsWith("En") }
+    }
 
     private suspend fun sendPushForTimetable(userLectureSyncResults: List<TimetableLectureSyncResult>) =
         coroutineScope {

--- a/batch/src/main/kotlin/sugangsnu/common/utils/SugangSnuExtensions.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/utils/SugangSnuExtensions.kt
@@ -5,17 +5,19 @@ import com.wafflestudio.snutt.coursebook.data.Coursebook
 import com.wafflestudio.snutt.lectures.data.Lecture
 import kotlin.reflect.KProperty1
 
+// 영문(_en) 필드는 한글 짝과 같은 항목명으로 표기한다.
+// 한/영이 함께 바뀌어도 호출부의 distinct()로 합쳐져 '비고, 기타'가 아닌 '비고'로 나간다.
 fun KProperty1<Lecture, *>.toKoreanFieldName(): String =
     when (this) {
-        Lecture::classification -> "교과 구분"
-        Lecture::department -> "학부"
-        Lecture::academicYear -> "학년"
-        Lecture::courseTitle -> "강의명"
+        Lecture::classification, Lecture::classificationEn -> "교과 구분"
+        Lecture::department, Lecture::departmentEn -> "학부"
+        Lecture::academicYear, Lecture::academicYearEn -> "학년"
+        Lecture::courseTitle, Lecture::courseTitleEn -> "강의명"
         Lecture::credit -> "학점"
-        Lecture::instructor -> "교수"
+        Lecture::instructor, Lecture::instructorEn -> "교수"
         Lecture::quota -> "정원"
-        Lecture::remark -> "비고"
-        Lecture::category -> "교양영역"
+        Lecture::remark, Lecture::remarkEn -> "비고"
+        Lecture::category, Lecture::categoryEn -> "교양영역"
         Lecture::classPlaceAndTimes -> "강의 시간/장소"
         Lecture::categoryPre2025 -> "구) 교양영역"
         else -> "기타"

--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -161,6 +161,11 @@ class SugangSnuSyncServiceImpl(
                         instructor = acc.instructor + lecture.instructor,
                         category = acc.category + lecture.category,
                         categoryPre2025 = acc.categoryPre2025 + lecture.categoryPre2025,
+                        classificationEn = acc.classificationEn + lecture.classificationEn,
+                        departmentEn = acc.departmentEn + lecture.departmentEn,
+                        academicYearEn = acc.academicYearEn + lecture.academicYearEn,
+                        instructorEn = acc.instructorEn + lecture.instructorEn,
+                        categoryEn = acc.categoryEn + lecture.categoryEn,
                     )
                 }.let { parsedTag ->
                     TagCollection(
@@ -193,6 +198,32 @@ class SugangSnuSyncServiceImpl(
                                 .sorted(),
                         categoryPre2025 =
                             parsedTag.categoryPre2025
+                                .filterNotNull()
+                                .filter { it.isNotBlank() }
+                                .sorted(),
+                        // 영문 태그 (en 필터 UI/검색 매칭용). KO 필터 규칙 그대로 미러.
+                        academicYearEn =
+                            parsedTag.academicYearEn
+                                .filterNotNull()
+                                .filter { it.length > 1 }
+                                .sorted(),
+                        classificationEn =
+                            parsedTag.classificationEn
+                                .filterNotNull()
+                                .filter { it.isNotBlank() }
+                                .sorted(),
+                        departmentEn =
+                            parsedTag.departmentEn
+                                .filterNotNull()
+                                .filter { it.isNotBlank() }
+                                .sorted(),
+                        instructorEn =
+                            parsedTag.instructorEn
+                                .filterNotNull()
+                                .filter { it.isNotBlank() }
+                                .sorted(),
+                        categoryEn =
+                            parsedTag.categoryEn
                                 .filterNotNull()
                                 .filter { it.isNotBlank() }
                                 .sorted(),
@@ -264,6 +295,13 @@ class SugangSnuSyncServiceImpl(
                         courseNumber = updatedLecture.newData.courseNumber
                         courseTitle = updatedLecture.newData.courseTitle
                         categoryPre2025 = updatedLecture.newData.categoryPre2025
+                        academicYearEn = updatedLecture.newData.academicYearEn
+                        categoryEn = updatedLecture.newData.categoryEn
+                        classificationEn = updatedLecture.newData.classificationEn
+                        departmentEn = updatedLecture.newData.departmentEn
+                        instructorEn = updatedLecture.newData.instructorEn
+                        remarkEn = updatedLecture.newData.remarkEn
+                        courseTitleEn = updatedLecture.newData.courseTitleEn
                     }!!
                 bookmarkRepository.updateLecture(bookmark.id!!, updatedBookmarkLecture)
             }.map { bookmark ->
@@ -318,6 +356,13 @@ class SugangSnuSyncServiceImpl(
                         courseNumber = updatedLecture.newData.courseNumber
                         courseTitle = updatedLecture.newData.courseTitle
                         categoryPre2025 = updatedLecture.newData.categoryPre2025
+                        academicYearEn = updatedLecture.newData.academicYearEn
+                        categoryEn = updatedLecture.newData.categoryEn
+                        classificationEn = updatedLecture.newData.classificationEn
+                        departmentEn = updatedLecture.newData.departmentEn
+                        instructorEn = updatedLecture.newData.instructorEn
+                        remarkEn = updatedLecture.newData.remarkEn
+                        courseTitleEn = updatedLecture.newData.courseTitleEn
                     }
                 timeTableRepository.updateTimetableLecture(timetable.id!!, updatedTimetableLecture!!).also {
                     eventPublisher.publishEvent(TimetableLectureModifiedEvent(updatedTimetableLecture))
@@ -439,4 +484,9 @@ data class ParsedTags(
     val category: Set<String?> = setOf(),
     val etc: Set<String?> = setOf(),
     val categoryPre2025: Set<String?> = setOf(),
+    val classificationEn: Set<String?> = setOf(),
+    val departmentEn: Set<String?> = setOf(),
+    val academicYearEn: Set<String?> = setOf(),
+    val instructorEn: Set<String?> = setOf(),
+    val categoryEn: Set<String?> = setOf(),
 )

--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -201,11 +201,11 @@ class SugangSnuSyncServiceImpl(
                                 .filterNotNull()
                                 .filter { it.isNotBlank() }
                                 .sorted(),
-                        // 영문 태그 (en 필터 UI/검색 매칭용). KO 필터 규칙 그대로 미러.
+                        // 영문 태그 (en 필터 UI/검색 매칭용). 영문 학년은 bare 숫자("1"~)라 length 필터 대신 blank만 제외.
                         academicYearEn =
                             parsedTag.academicYearEn
                                 .filterNotNull()
-                                .filter { it.length > 1 }
+                                .filter { it.isNotBlank() }
                                 .sorted(),
                         classificationEn =
                             parsedTag.classificationEn

--- a/core/src/main/kotlin/bookmark/service/BookmarkService.kt
+++ b/core/src/main/kotlin/bookmark/service/BookmarkService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt.bookmark.service
 
 import com.wafflestudio.snutt.bookmark.data.Bookmark
 import com.wafflestudio.snutt.bookmark.repository.BookmarkRepository
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.common.exception.LectureNotFoundException
 import com.wafflestudio.snutt.evaluation.service.EvService
@@ -32,7 +33,10 @@ interface BookmarkService {
         lectureId: String,
     ): Bookmark
 
-    suspend fun convertBookmarkLecturesToBookmarkLectureDtos(bookmarkLectures: List<BookmarkLecture>): List<BookmarkLectureDto>
+    suspend fun convertBookmarkLecturesToBookmarkLectureDtos(
+        bookmarkLectures: List<BookmarkLecture>,
+        language: Language = Language.KO,
+    ): List<BookmarkLectureDto>
 }
 
 @Service
@@ -86,12 +90,15 @@ class BookmarkServiceImpl(
         )
     }
 
-    override suspend fun convertBookmarkLecturesToBookmarkLectureDtos(bookmarkLectures: List<BookmarkLecture>): List<BookmarkLectureDto> {
+    override suspend fun convertBookmarkLecturesToBookmarkLectureDtos(
+        bookmarkLectures: List<BookmarkLecture>,
+        language: Language,
+    ): List<BookmarkLectureDto> {
         val snuttIdtoLectureMap =
             snuttEvService.getSummariesByIds(bookmarkLectures.map { it.id!! }).associateBy { it.snuttId }
         return bookmarkLectures.map { bookmarkLecture ->
             val snuttEvLecture = snuttIdtoLectureMap[bookmarkLecture.id]
-            BookmarkLectureDto(bookmarkLecture, snuttEvLecture)
+            BookmarkLectureDto(bookmarkLecture, snuttEvLecture, language)
         }
     }
 }

--- a/core/src/main/kotlin/common/client/ClientInfo.kt
+++ b/core/src/main/kotlin/common/client/ClientInfo.kt
@@ -7,4 +7,5 @@ data class ClientInfo(
     val appVersion: AppVersion?,
     val deviceId: String?,
     val deviceModel: String?,
+    val language: Language = Language.KO,
 )

--- a/core/src/main/kotlin/common/client/Language.kt
+++ b/core/src/main/kotlin/common/client/Language.kt
@@ -18,10 +18,10 @@ enum class Language {
 fun Language.select(
     ko: String,
     en: String?,
-): String = if (this == Language.EN) en ?: ko else ko
+): String = if (this == Language.EN) en?.takeIf { it.isNotBlank() } ?: ko else ko
 
 @JvmName("selectNullable")
 fun Language.select(
     ko: String?,
     en: String?,
-): String? = if (this == Language.EN) en ?: ko else ko
+): String? = if (this == Language.EN) en?.takeIf { it.isNotBlank() } ?: ko else ko

--- a/core/src/main/kotlin/common/client/Language.kt
+++ b/core/src/main/kotlin/common/client/Language.kt
@@ -1,0 +1,26 @@
+package com.wafflestudio.snutt.common.client
+
+enum class Language {
+    KO,
+    EN,
+    ;
+
+    companion object {
+        private val ENUM_MAP: Map<String, Language> = Language.entries.associateBy { it.toString().lowercase() }
+
+        fun from(language: String?): Language? = language?.let { ENUM_MAP[language.lowercase()] }
+    }
+}
+
+/**
+ * 읽기 시점 언어 선택 + 폴백. EN이면 en 우선, 없으면 ko. KO면 항상 ko.
+ */
+fun Language.select(
+    ko: String,
+    en: String?,
+): String = if (this == Language.EN) en ?: ko else ko
+
+fun Language.select(
+    ko: String?,
+    en: String?,
+): String? = if (this == Language.EN) en ?: ko else ko

--- a/core/src/main/kotlin/common/client/Language.kt
+++ b/core/src/main/kotlin/common/client/Language.kt
@@ -20,6 +20,7 @@ fun Language.select(
     en: String?,
 ): String = if (this == Language.EN) en ?: ko else ko
 
+@JvmName("selectNullable")
 fun Language.select(
     ko: String?,
     en: String?,

--- a/core/src/main/kotlin/lectures/data/BookmarkLecture.kt
+++ b/core/src/main/kotlin/lectures/data/BookmarkLecture.kt
@@ -31,6 +31,20 @@ data class BookmarkLecture(
     @Field("course_title")
     var courseTitle: String,
     var categoryPre2025: String?,
+    @Field("academic_year_en")
+    var academicYearEn: String? = null,
+    @Field("category_en")
+    var categoryEn: String? = null,
+    @Field("classification_en")
+    var classificationEn: String? = null,
+    @Field("department_en")
+    var departmentEn: String? = null,
+    @Field("instructor_en")
+    var instructorEn: String? = null,
+    @Field("remark_en")
+    var remarkEn: String? = null,
+    @Field("course_title_en")
+    var courseTitleEn: String? = null,
 )
 
 fun BookmarkLecture(lecture: Lecture): BookmarkLecture =
@@ -50,4 +64,11 @@ fun BookmarkLecture(lecture: Lecture): BookmarkLecture =
         courseNumber = lecture.courseNumber,
         courseTitle = lecture.courseTitle,
         categoryPre2025 = lecture.categoryPre2025,
+        academicYearEn = lecture.academicYearEn,
+        categoryEn = lecture.categoryEn,
+        classificationEn = lecture.classificationEn,
+        departmentEn = lecture.departmentEn,
+        instructorEn = lecture.instructorEn,
+        remarkEn = lecture.remarkEn,
+        courseTitleEn = lecture.courseTitleEn,
     )

--- a/core/src/main/kotlin/lectures/data/Lecture.kt
+++ b/core/src/main/kotlin/lectures/data/Lecture.kt
@@ -38,6 +38,20 @@ data class Lecture(
     var wasFull: Boolean = false,
     var evInfo: EvInfo? = null,
     var categoryPre2025: String?,
+    @Field("academic_year_en")
+    var academicYearEn: String? = null,
+    @Field("category_en")
+    var categoryEn: String? = null,
+    @Field("classification_en")
+    var classificationEn: String? = null,
+    @Field("department_en")
+    var departmentEn: String? = null,
+    @Field("instructor_en")
+    var instructorEn: String? = null,
+    @Field("remark_en")
+    var remarkEn: String? = null,
+    @Field("course_title_en")
+    var courseTitleEn: String? = null,
 ) {
     infix fun equalsMetadata(other: Lecture): Boolean =
         this === other ||
@@ -57,6 +71,13 @@ data class Lecture(
                     year == other.year &&
                     courseNumber == other.courseNumber &&
                     courseTitle == other.courseTitle &&
-                    categoryPre2025 == other.categoryPre2025
+                    categoryPre2025 == other.categoryPre2025 &&
+                    academicYearEn == other.academicYearEn &&
+                    categoryEn == other.categoryEn &&
+                    classificationEn == other.classificationEn &&
+                    departmentEn == other.departmentEn &&
+                    instructorEn == other.instructorEn &&
+                    remarkEn == other.remarkEn &&
+                    courseTitleEn == other.courseTitleEn
             )
 }

--- a/core/src/main/kotlin/lectures/dto/BookmarkLectureDto.kt
+++ b/core/src/main/kotlin/lectures/dto/BookmarkLectureDto.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snutt.lectures.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.Language
+import com.wafflestudio.snutt.common.client.select
 import com.wafflestudio.snutt.evaluation.dto.SnuttEvLectureSummaryDto
 import com.wafflestudio.snutt.lectures.data.BookmarkLecture
 
@@ -31,21 +33,22 @@ data class BookmarkLectureDto(
 fun BookmarkLectureDto(
     lecture: BookmarkLecture,
     snuttEvLecture: SnuttEvLectureSummaryDto? = null,
+    language: Language = Language.KO,
 ): BookmarkLectureDto =
     BookmarkLectureDto(
         id = lecture.id,
-        academicYear = lecture.academicYear,
-        category = lecture.category,
+        academicYear = language.select(lecture.academicYear, lecture.academicYearEn),
+        category = language.select(lecture.category, lecture.categoryEn),
         classTimes = lecture.classPlaceAndTimes.map { ClassPlaceAndTimeLegacyDto(it) },
-        classification = lecture.classification,
+        classification = language.select(lecture.classification, lecture.classificationEn),
         credit = lecture.credit,
-        department = lecture.department,
-        instructor = lecture.instructor,
+        department = language.select(lecture.department, lecture.departmentEn),
+        instructor = language.select(lecture.instructor, lecture.instructorEn),
         quota = lecture.quota,
         freshmanQuota = lecture.freshmanQuota,
-        remark = lecture.remark,
+        remark = language.select(lecture.remark, lecture.remarkEn),
         lectureNumber = lecture.lectureNumber,
         courseNumber = lecture.courseNumber,
-        courseTitle = lecture.courseTitle,
+        courseTitle = language.select(lecture.courseTitle, lecture.courseTitleEn),
         snuttEvLecture = snuttEvLecture,
     )

--- a/core/src/main/kotlin/lectures/dto/LectureDto.kt
+++ b/core/src/main/kotlin/lectures/dto/LectureDto.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snutt.lectures.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.Language
+import com.wafflestudio.snutt.common.client.select
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.evaluation.dto.SnuttEvLectureSummaryDto
 import com.wafflestudio.snutt.lectures.data.Lecture
@@ -37,24 +39,25 @@ data class LectureDto(
 fun LectureDto(
     lecture: Lecture,
     snuttevLecture: SnuttEvLectureSummaryDto? = null,
+    language: Language = Language.KO,
 ): LectureDto =
     LectureDto(
         id = lecture.id,
-        academicYear = lecture.academicYear,
-        category = lecture.category,
+        academicYear = language.select(lecture.academicYear, lecture.academicYearEn),
+        category = language.select(lecture.category, lecture.categoryEn),
         classPlaceAndTimes = lecture.classPlaceAndTimes.map { ClassPlaceAndTimeLegacyDto(it) },
-        classification = lecture.classification,
+        classification = language.select(lecture.classification, lecture.classificationEn),
         credit = lecture.credit,
-        department = lecture.department,
-        instructor = lecture.instructor,
+        department = language.select(lecture.department, lecture.departmentEn),
+        instructor = language.select(lecture.instructor, lecture.instructorEn),
         lectureNumber = lecture.lectureNumber,
         quota = lecture.quota,
         freshmanQuota = lecture.freshmanQuota,
-        remark = lecture.remark,
+        remark = language.select(lecture.remark, lecture.remarkEn),
         semester = lecture.semester,
         year = lecture.year,
         courseNumber = lecture.courseNumber,
-        courseTitle = lecture.courseTitle,
+        courseTitle = language.select(lecture.courseTitle, lecture.courseTitleEn),
         registrationCount = lecture.registrationCount,
         wasFull = lecture.wasFull,
         snuttEvLecture = snuttevLecture,

--- a/core/src/main/kotlin/lectures/dto/SearchDto.kt
+++ b/core/src/main/kotlin/lectures/dto/SearchDto.kt
@@ -1,10 +1,12 @@
 package com.wafflestudio.snutt.lectures.dto
 
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.Semester
 
 data class SearchDto(
     val year: Int,
     val semester: Semester,
+    val language: Language = Language.KO,
     val query: String? = null,
     val classification: List<String>? = null,
     val credit: List<Int>? = null,

--- a/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
+++ b/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.lectures.repository
 
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.SortCriteria
 import com.wafflestudio.snutt.common.extension.isEqualTo
 import com.wafflestudio.snutt.lectures.data.ClassPlaceAndTime
@@ -41,13 +42,34 @@ class LectureCustomRepositoryImpl(
                         Criteria().andOperator(
                             listOfNotNull(
                                 Lecture::year isEqualTo searchCondition.year and Lecture::semester isEqualTo searchCondition.semester,
-                                searchCondition.query?.let { makeSearchCriteriaFromQuery(it) },
+                                searchCondition.query?.let { makeSearchCriteriaFromQuery(it, searchCondition.language) },
                                 searchCondition.credit?.takeIf { it.isNotEmpty() }?.let { Lecture::credit inValues it },
-                                searchCondition.academicYear?.takeIf { it.isNotEmpty() }?.let { Lecture::academicYear inValues it },
+                                searchCondition.academicYear?.takeIf { it.isNotEmpty() }?.let {
+                                    if (searchCondition.isEn()) {
+                                        Criteria().orOperator(Lecture::academicYear inValues it, Lecture::academicYearEn inValues it)
+                                    } else {
+                                        Lecture::academicYear inValues it
+                                    }
+                                },
                                 searchCondition.courseNumber?.takeIf { it.isNotEmpty() }?.let { Lecture::courseNumber inValues it },
-                                searchCondition.classification?.takeIf { it.isNotEmpty() }?.let { Lecture::classification inValues it },
+                                searchCondition.classification?.takeIf { it.isNotEmpty() }?.let {
+                                    if (searchCondition.isEn()) {
+                                        Criteria().orOperator(
+                                            Lecture::classification inValues it,
+                                            Lecture::classificationEn inValues it,
+                                        )
+                                    } else {
+                                        Lecture::classification inValues it
+                                    }
+                                },
                                 listOfNotNull(
-                                    searchCondition.category?.takeIf { it.isNotEmpty() }?.let { Lecture::category inValues it },
+                                    searchCondition.category?.takeIf { it.isNotEmpty() }?.let {
+                                        if (searchCondition.isEn()) {
+                                            Criteria().orOperator(Lecture::category inValues it, Lecture::categoryEn inValues it)
+                                        } else {
+                                            Lecture::category inValues it
+                                        }
+                                    },
                                     searchCondition.categoryPre2025
                                         ?.takeIf {
                                             it.isNotEmpty()
@@ -55,7 +77,13 @@ class LectureCustomRepositoryImpl(
                                 ).takeIf { it.isNotEmpty() }?.let {
                                     Criteria().orOperator(it)
                                 },
-                                searchCondition.department?.takeIf { it.isNotEmpty() }?.let { Lecture::department inValues it },
+                                searchCondition.department?.takeIf { it.isNotEmpty() }?.let {
+                                    if (searchCondition.isEn()) {
+                                        Criteria().orOperator(Lecture::department inValues it, Lecture::departmentEn inValues it)
+                                    } else {
+                                        Lecture::department inValues it
+                                    }
+                                },
                                 searchCondition.times?.takeIf { it.isNotEmpty() }?.let { searchTimes ->
                                     Criteria().andOperator(
                                         Lecture::classPlaceAndTimes ne listOf(),
@@ -107,9 +135,26 @@ class LectureCustomRepositoryImpl(
                     .limit(searchCondition.limit),
             ).asFlow()
 
-    private fun makeSearchCriteriaFromQuery(query: String): Criteria =
+    private fun SearchDto.isEn(): Boolean = language == Language.EN
+
+    private fun makeSearchCriteriaFromQuery(
+        query: String,
+        language: Language,
+    ): Criteria =
         Criteria().andOperator(
             query.split(' ').map { keyword ->
+                // EN 검색은 스마트검색(특수키워드/학과접미사) 미지원. 제목/교수/과목번호/강좌번호 단순 매칭만.
+                // 과거 학기(_en null) 커버 위해 ko 필드도 OR 매칭.
+                if (language == Language.EN) {
+                    return@map Criteria().orOperator(
+                        Lecture::courseTitle.regex(Regex.escape(keyword), "i"),
+                        Lecture::courseTitleEn.regex(Regex.escape(keyword), "i"),
+                        Lecture::instructor.regex(Regex.escape(keyword), "i"),
+                        Lecture::instructorEn.regex(Regex.escape(keyword), "i"),
+                        Lecture::courseNumber isEqualTo keyword,
+                        Lecture::lectureNumber isEqualTo keyword,
+                    )
+                }
                 val fuzzyKeyword = keyword.toCharArray().joinToString(".*") { Regex.escape(it.toString()) }
                 when {
                     keyword == "전공" -> {

--- a/core/src/main/kotlin/lectures/service/LectureService.kt
+++ b/core/src/main/kotlin/lectures/service/LectureService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.lectures.service
 
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.evaluation.service.EvService
 import com.wafflestudio.snutt.lectures.data.Lecture
@@ -26,7 +27,10 @@ interface LectureService {
 
     fun search(query: SearchDto): Flow<Lecture>
 
-    suspend fun convertLecturesToLectureDtos(lectures: Iterable<Lecture>): List<LectureDto>
+    suspend fun convertLecturesToLectureDtos(
+        lectures: Iterable<Lecture>,
+        language: Language = Language.KO,
+    ): List<LectureDto>
 }
 
 @Service
@@ -49,12 +53,15 @@ class LectureServiceImpl(
 
     override fun search(query: SearchDto): Flow<Lecture> = lectureRepository.searchLectures(query)
 
-    override suspend fun convertLecturesToLectureDtos(lectures: Iterable<Lecture>): List<LectureDto> {
+    override suspend fun convertLecturesToLectureDtos(
+        lectures: Iterable<Lecture>,
+        language: Language,
+    ): List<LectureDto> {
         val snuttIdToEvLectureMap =
             snuttEvService.getSummariesByIds(lectures.map { it.id!! }).associateBy { it.snuttId }
         return lectures.map { lecture ->
             val snuttEvLecture = snuttIdToEvLectureMap[lecture.id]
-            LectureDto(lecture, snuttEvLecture)
+            LectureDto(lecture, snuttEvLecture, language)
         }
     }
 }

--- a/core/src/main/kotlin/tag/data/TagList.kt
+++ b/core/src/main/kotlin/tag/data/TagList.kt
@@ -33,4 +33,14 @@ data class TagCollection(
     val instructor: List<String>,
     val category: List<String>,
     val categoryPre2025: List<String> = listOf(),
+    @Field("classification_en")
+    val classificationEn: List<String> = listOf(),
+    @Field("department_en")
+    val departmentEn: List<String> = listOf(),
+    @Field("academic_year_en")
+    val academicYearEn: List<String> = listOf(),
+    @Field("instructor_en")
+    val instructorEn: List<String> = listOf(),
+    @Field("category_en")
+    val categoryEn: List<String> = listOf(),
 )

--- a/core/src/main/kotlin/tag/data/TagListResponse.kt
+++ b/core/src/main/kotlin/tag/data/TagListResponse.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt.tag.data
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.SortCriteria
 
 data class TagListResponse(
@@ -17,14 +18,22 @@ data class TagListResponse(
     val categoryPre2025: List<String>,
 )
 
-fun TagListResponse(tagList: TagList) =
+fun TagListResponse(
+    tagList: TagList,
+    language: Language = Language.KO,
+) = run {
+    // EN이면 영문 태그 우선. 영문 태그가 비어있으면(과거 학기 미백필) 한글로 폴백.
+    fun localize(
+        ko: List<String>,
+        en: List<String>,
+    ): List<String> = if (language == Language.EN) en.ifEmpty { ko } else ko
     TagListResponse(
-        classification = tagList.tagCollection.classification,
-        department = tagList.tagCollection.department,
-        academicYear = tagList.tagCollection.academicYear,
+        classification = localize(tagList.tagCollection.classification, tagList.tagCollection.classificationEn),
+        department = localize(tagList.tagCollection.department, tagList.tagCollection.departmentEn),
+        academicYear = localize(tagList.tagCollection.academicYear, tagList.tagCollection.academicYearEn),
         credit = tagList.tagCollection.credit,
-        instructor = tagList.tagCollection.instructor,
-        category = tagList.tagCollection.category,
+        instructor = localize(tagList.tagCollection.instructor, tagList.tagCollection.instructorEn),
+        category = localize(tagList.tagCollection.category, tagList.tagCollection.categoryEn),
         sortCriteria =
             SortCriteria.entries
                 .sortedBy { it.value }
@@ -33,3 +42,4 @@ fun TagListResponse(tagList: TagList) =
         updatedAt = tagList.updatedAt.toEpochMilli(),
         categoryPre2025 = tagList.tagCollection.categoryPre2025,
     )
+}

--- a/core/src/main/kotlin/timetables/data/TimetableLecture.kt
+++ b/core/src/main/kotlin/timetables/data/TimetableLecture.kt
@@ -45,6 +45,21 @@ data class TimetableLecture(
     @Indexed
     var lectureId: String? = null,
     var categoryPre2025: String?,
+    @Field("academic_year_en")
+    @param:JsonProperty("academic_year_en")
+    var academicYearEn: String? = null,
+    @Field("category_en")
+    var categoryEn: String? = null,
+    @Field("classification_en")
+    var classificationEn: String? = null,
+    @Field("department_en")
+    var departmentEn: String? = null,
+    @Field("instructor_en")
+    var instructorEn: String? = null,
+    @Field("remark_en")
+    var remarkEn: String? = null,
+    @Field("course_title_en")
+    var courseTitleEn: String? = null,
 )
 
 fun TimetableLecture(
@@ -69,4 +84,11 @@ fun TimetableLecture(
     colorIndex = colorIndex,
     color = color,
     categoryPre2025 = lecture.categoryPre2025,
+    academicYearEn = lecture.academicYearEn,
+    categoryEn = lecture.categoryEn,
+    classificationEn = lecture.classificationEn,
+    departmentEn = lecture.departmentEn,
+    instructorEn = lecture.instructorEn,
+    remarkEn = lecture.remarkEn,
+    courseTitleEn = lecture.courseTitleEn,
 )

--- a/core/src/main/kotlin/timetables/dto/TimetableDto.kt
+++ b/core/src/main/kotlin/timetables/dto/TimetableDto.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt.timetables.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.enums.BasicThemeType
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.timetables.data.Timetable
@@ -19,11 +20,13 @@ data class TimetableDto(
     var updatedAt: Instant = Instant.now(),
 )
 
-fun TimetableDto(timetable: Timetable) =
-    TimetableDto(
-        timetable = timetable,
-        lectures = timetable.lectures.map { TimetableLectureDto(it) },
-    )
+fun TimetableDto(
+    timetable: Timetable,
+    language: Language = Language.KO,
+) = TimetableDto(
+    timetable = timetable,
+    lectures = timetable.lectures.map { TimetableLectureDto(it, language = language) },
+)
 
 fun TimetableDto(
     timetable: Timetable,

--- a/core/src/main/kotlin/timetables/dto/TimetableLectureDto.kt
+++ b/core/src/main/kotlin/timetables/dto/TimetableLectureDto.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snutt.timetables.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snutt.common.client.Language
+import com.wafflestudio.snutt.common.client.select
 import com.wafflestudio.snutt.evaluation.dto.SnuttEvLectureIdDto
 import com.wafflestudio.snutt.lectures.dto.ClassPlaceAndTimeDto
 import com.wafflestudio.snutt.lectures.dto.ClassPlaceAndTimeLegacyDto
@@ -32,21 +34,22 @@ data class TimetableLectureDto(
 fun TimetableLectureDto(
     timetableLecture: TimetableLecture,
     snuttEvLecture: SnuttEvLectureIdDto? = null,
+    language: Language = Language.KO,
 ) = TimetableLectureDto(
     id = timetableLecture.id,
-    academicYear = timetableLecture.academicYear,
-    category = timetableLecture.category,
+    academicYear = language.select(timetableLecture.academicYear, timetableLecture.academicYearEn),
+    category = language.select(timetableLecture.category, timetableLecture.categoryEn),
     classPlaceAndTimes = timetableLecture.classPlaceAndTimes.map { ClassPlaceAndTimeDto(it) },
-    classification = timetableLecture.classification,
+    classification = language.select(timetableLecture.classification, timetableLecture.classificationEn),
     credit = timetableLecture.credit,
-    department = timetableLecture.department,
-    instructor = timetableLecture.instructor,
+    department = language.select(timetableLecture.department, timetableLecture.departmentEn),
+    instructor = language.select(timetableLecture.instructor, timetableLecture.instructorEn),
     lectureNumber = timetableLecture.lectureNumber,
     quota = timetableLecture.quota,
     freshmanQuota = timetableLecture.freshmanQuota,
-    remark = timetableLecture.remark,
+    remark = language.select(timetableLecture.remark, timetableLecture.remarkEn),
     courseNumber = timetableLecture.courseNumber,
-    courseTitle = timetableLecture.courseTitle,
+    courseTitle = language.select(timetableLecture.courseTitle, timetableLecture.courseTitleEn),
     color = timetableLecture.color,
     colorIndex = timetableLecture.colorIndex,
     lectureId = timetableLecture.lectureId,
@@ -87,21 +90,22 @@ data class TimetableLectureLegacyDto(
 fun TimetableLectureLegacyDto(
     timetableLecture: TimetableLecture,
     snuttEvLecture: SnuttEvLectureIdDto? = null,
+    language: Language = Language.KO,
 ) = TimetableLectureLegacyDto(
     id = timetableLecture.id,
-    academicYear = timetableLecture.academicYear,
-    category = timetableLecture.category,
+    academicYear = language.select(timetableLecture.academicYear, timetableLecture.academicYearEn),
+    category = language.select(timetableLecture.category, timetableLecture.categoryEn),
     classPlaceAndTimes = timetableLecture.classPlaceAndTimes.map { ClassPlaceAndTimeLegacyDto(it) },
-    classification = timetableLecture.classification,
+    classification = language.select(timetableLecture.classification, timetableLecture.classificationEn),
     credit = timetableLecture.credit,
-    department = timetableLecture.department,
-    instructor = timetableLecture.instructor,
+    department = language.select(timetableLecture.department, timetableLecture.departmentEn),
+    instructor = language.select(timetableLecture.instructor, timetableLecture.instructorEn),
     lectureNumber = timetableLecture.lectureNumber,
     quota = timetableLecture.quota,
     freshmanQuota = timetableLecture.freshmanQuota,
-    remark = timetableLecture.remark,
+    remark = language.select(timetableLecture.remark, timetableLecture.remarkEn),
     courseNumber = timetableLecture.courseNumber,
-    courseTitle = timetableLecture.courseTitle,
+    courseTitle = language.select(timetableLecture.courseTitle, timetableLecture.courseTitleEn),
     color = timetableLecture.color,
     colorIndex = timetableLecture.colorIndex,
     lectureId = timetableLecture.lectureId,

--- a/core/src/main/kotlin/timetables/service/TimetableService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.timetables.service
 
+import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.dynamiclink.client.DynamicLinkClient
 import com.wafflestudio.snutt.common.dynamiclink.dto.DynamicLinkResponse
 import com.wafflestudio.snutt.common.enums.BasicThemeType
@@ -102,9 +103,15 @@ interface TimetableService {
         timetableId: String,
     )
 
-    suspend fun convertTimetableToTimetableLegacyDto(timetable: Timetable): TimetableLegacyDto
+    suspend fun convertTimetableToTimetableLegacyDto(
+        timetable: Timetable,
+        language: Language = Language.KO,
+    ): TimetableLegacyDto
 
-    suspend fun convertTimetableToTimetableDto(timetable: Timetable): TimetableDto
+    suspend fun convertTimetableToTimetableDto(
+        timetable: Timetable,
+        language: Language = Language.KO,
+    ): TimetableDto
 }
 
 @Service
@@ -333,17 +340,23 @@ class TimetableServiceImpl(
         timetableRepository.save(table.copy(isPrimary = false))
     }
 
-    override suspend fun convertTimetableToTimetableLegacyDto(timetable: Timetable): TimetableLegacyDto {
+    override suspend fun convertTimetableToTimetableLegacyDto(
+        timetable: Timetable,
+        language: Language,
+    ): TimetableLegacyDto {
         val evLectureIdMap =
             evService.getEvIdsBySnuttIds(timetable.lectures.mapNotNull { it.lectureId }).associateBy { it.snuttId }
-        val timetableLectures = timetable.lectures.map { TimetableLectureLegacyDto(it, evLectureIdMap[it.lectureId]) }
+        val timetableLectures = timetable.lectures.map { TimetableLectureLegacyDto(it, evLectureIdMap[it.lectureId], language) }
         return TimetableLegacyDto(timetable, timetableLectures)
     }
 
-    override suspend fun convertTimetableToTimetableDto(timetable: Timetable): TimetableDto {
+    override suspend fun convertTimetableToTimetableDto(
+        timetable: Timetable,
+        language: Language,
+    ): TimetableDto {
         val evLectureIdMap =
             evService.getEvIdsBySnuttIds(timetable.lectures.mapNotNull { it.lectureId }).associateBy { it.snuttId }
-        val timetableLectures = timetable.lectures.map { TimetableLectureDto(it, evLectureIdMap[it.lectureId]) }
+        val timetableLectures = timetable.lectures.map { TimetableLectureDto(it, evLectureIdMap[it.lectureId], language) }
         return TimetableDto(timetable, timetableLectures)
     }
 }


### PR DESCRIPTION
## 언어 전달
- `x-language: ko | en` 헤더로 언어를 전달한다. 값이 없거나 알 수 없으면 `ko`로 폴백.
- 기존 `x-*` 클라이언트 메타데이터와 동일하게 `ClientInfo`에 실어 컨트롤러로 주입한다.

## 저장·응답 전략
- `Lecture`(및 시간표/북마크 스냅샷, `TagCollection`)에 nullable 영문 필드를 병렬로 추가.
  기존 flat 스키마를 그대로 유지한다.
- 응답은 **필드명 불변, 값만 언어에 맞춰** 채운다. 영문이 없으면 한글로 폴백(`en ?: ko`)하며,
  이는 읽기 시점에 적용되므로 과거 학기(영문 null)는 자동으로 한글로 내려간다.
- 헤더가 없으면 `ko`로 동작 → **응답 스키마 변화 없음(하위호환)**. 즉, 기존 요청에도 정상적으로 작동하며 기존 응답 유지.

## 수집·동기화
- 배치가 영문 엑셀 컬럼과 강의별 팝업의 영문 필드를 읽어 영문 값을 채운다
  (기존 한글과 동일하게 팝업 우선, 엑셀 폴백).
- 강의 변경 시 유저 시간표/북마크 스냅샷에도 영문을 반영하고, `equalsMetadata`·태그 목록에도
  영문을 포함한다.
- 적용 대상: 검색 / 태그 / 시간표 / 북마크 등 강의를 반환하는 읽기 엔드포인트.

## 검색
- EN 모드 텍스트 검색: 제목·교수(영/한 모두)·과목번호·강좌번호 단순 매칭.
- EN 모드 필터(학과/분야/교과구분/이수과정): 태그 목록이 영문으로 내려가므로,
  선택된 영문 값을 `_en` 컬럼에도 매칭하도록 처리.
- 스마트검색 및 한글 검색 경로는 기존 그대로 유지.

## 후속작업
- 과거 학기 영문 채우기는 아직 구현 안 함.
- 영문 스마트검색 지원