### PR TITLE
ci: native image 빌드 소요 시간 계측 로깅 추가

### DIFF
--- a/.github/scripts/summarize-docker-build.sh
+++ b/.github/scripts/summarize-docker-build.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# docker build 로그에서 시간 정보를 뽑아 markdown 요약을 stdout 으로 출력한다.
+# GitHub Actions 의 $GITHUB_STEP_SUMMARY 에 붙여 쓰는 것을 전제로 한다.
+#
+# 사용법: .github/scripts/summarize-docker-build.sh <docker-build-log>
+#
+# 뽑아내는 것:
+#   1. BuildKit 레이어별 소요 시간 (베이스 이미지 pull / COPY / 각 RUN)
+#   2. gradle/build-phase.sh 가 남긴 phase 요약
+#   3. gradle/build-timing.init.gradle 이 남긴 태스크별 소요 시간
+#   4. GraalVM native-image 자체 리포트 (빌드에 할당된 자원, 단계별 비중)
+
+set -euo pipefail
+
+log_file="${1:-}"
+if [ -z "$log_file" ] || [ ! -f "$log_file" ]; then
+    echo "> docker build 로그를 찾을 수 없어 타이밍 요약을 건너뜁니다. (${log_file:-<none>})"
+    exit 0
+fi
+
+# BuildKit 은 RUN 의 stdout 에도 "#12 5.432 " 같은 접두사를 붙인다. 내용 매칭 전에 벗겨낸다.
+stripped=$(mktemp)
+trap 'rm -f "$stripped"' EXIT
+sed -E 's/^#[0-9]+ ([0-9]+\.[0-9]+ )?//' "$log_file" > "$stripped"
+
+echo "### 1. Docker 레이어별 소요 시간"
+echo ""
+layer_rows=$(
+    awk '
+        match($0, /^#[0-9]+ /) {
+            id = substr($0, 2, RLENGTH - 2)
+            rest = substr($0, RLENGTH + 1)
+
+            if (rest ~ /^DONE [0-9]/) {
+                split(rest, parts, " ")
+                seconds = parts[2]
+                sub(/s$/, "", seconds)
+                printf "%s\t%s\n", seconds, (id in layer_name ? layer_name[id] : "#" id)
+                next
+            }
+            if (rest ~ /^CACHED/) {
+                printf "0.0\t%s (CACHED)\n", (id in layer_name ? layer_name[id] : "#" id)
+                next
+            }
+            # 첫 줄이 그 레이어의 설명이다. 진행률/출력 줄은 이름으로 쓰지 않는다.
+            if (!(id in layer_name) && rest !~ /^([0-9]+\.[0-9]+ |ERROR|CANCELED|WARN)/) {
+                layer_name[id] = rest
+            }
+        }
+    ' "$log_file" | sort -rn | head -25 || true
+)
+
+if [ -z "$layer_rows" ]; then
+    echo "> BuildKit 레이어 정보를 찾지 못했습니다. \`docker build --progress=plain\` 으로 실행했는지 확인하세요."
+else
+    echo "| 소요 시간 | 레이어 |"
+    echo "| ---: | --- |"
+    printf '%s\n' "$layer_rows" | while IFS=$'\t' read -r seconds name; do
+        # markdown 표가 깨지지 않도록 파이프를 이스케이프하고 길이를 자른다.
+        name=${name//|/\\|}
+        if [ "${#name}" -gt 110 ]; then
+            name="${name:0:110}…"
+        fi
+        printf '| %ss | `%s` |\n' "$seconds" "$name"
+    done
+fi
+echo ""
+
+emit_block() {
+    local heading="$1"
+    local content="$2"
+    local empty_note="$3"
+
+    echo "### $heading"
+    echo ""
+    if [ -z "$content" ]; then
+        echo "> $empty_note"
+    else
+        echo '```'
+        printf '%s\n' "$content"
+        echo '```'
+    fi
+    echo ""
+}
+
+phase_summary=$(sed -n '/DOCKER BUILD PHASE SUMMARY/,/^=\{20,\}$/p' "$stripped" | head -40 || true)
+emit_block "2. Gradle phase 별 소요 시간" "$phase_summary" \
+    "phase 요약이 없습니다. Dockerfile 이 gradle/build-phase.sh 를 쓰는지 확인하세요."
+
+task_timing=$(sed -n '/^BUILD TIMING \[/,/^=\{20,\}$/p' "$stripped" | head -200 || true)
+emit_block "3. Gradle 태스크별 소요 시간" "$task_timing" \
+    "태스크 타이밍이 없습니다. gradle/build-timing.init.gradle 이 적용됐는지 확인하세요."
+
+# GraalVM native-image 는 마지막에 단계별 비중과 사용 자원을 표로 찍는다.
+# 러너의 메모리/CPU 가 부족하면 여기서 바로 드러난다.
+native_report=$(
+    grep -E \
+        -e '^ ?- [0-9.]+GB of memory' \
+        -e '^ ?- [0-9]+ thread\(s\)' \
+        -e '^ ?- [0-9.]+GB of (memory|disk)' \
+        -e '\([0-9]+\.[0-9]%\) (Classlist|Setup|Analysis|Universe|Building|Parsing|Inlining|Compiling|Layouting|Image|Write|Total)' \
+        -e '^Finished generating' \
+        -e 'Peak RSS' \
+        -e 'GCs' \
+        "$stripped" | head -60 || true
+)
+emit_block "4. GraalVM native-image 리포트" "$native_report" \
+    "native-image 리포트를 찾지 못했습니다. (native 빌드가 아니거나 캐시된 레이어일 수 있습니다.)"

--- a/.github/workflows/_deploy-native.yml
+++ b/.github/workflows/_deploy-native.yml
@@ -36,22 +36,50 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # runner 컨텍스트는 job 레벨 env 에서 못 쓰기 때문에 여기서 채운다.
+      - name: Prepare build metadata
+        run: |
+          echo "DOCKER_BUILD_LOG=${RUNNER_TEMP}/docker-build.log" >> $GITHUB_ENV
+          echo "BUILD_LOG_ARTIFACT_NAME=docker-build-log-${OCIR_REPOSITORY//\//-}-${IMAGE_TAG}" >> $GITHUB_ENV
+
       - name: Login to OCIR
         run: echo "${{ secrets.OCI_AUTH_TOKEN }}" | docker login $OCIR_REGISTRY -u ax1dvc8vmenm/members/snutt-deployer --password-stdin
 
-      - name: Docker build, tag, and push image to OCIR
-        id: build-push-image
+      # native image 빌드가 오래 걸리므로 build 와 push 를 별도 스텝으로 나눈다.
+      # 스텝이 나뉘어야 GitHub Actions 가 각각의 소요 시간을 따로 보여준다.
+      - name: Docker build
+        id: build
         run: |
+          set -euo pipefail
           echo "${{ github.token }}" > .github_token
+          # 빌드가 실패해도 소요 시간은 기록한다. 느려서 죽는 경우가 바로 그 정보를 봐야 하는 경우다.
+          started_at=$(date +%s)
+          build_exit_code=0
           docker build \
+            --progress=plain \
             --secret id=github_token,src=./.github_token \
             -f ${{ inputs.dockerfile }} \
             -t $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG \
             . \
-            --platform linux/arm64
-          rm -f .github_token
-          docker push $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG
-          echo "image=$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+            --platform linux/arm64 \
+            2>&1 | tee "$DOCKER_BUILD_LOG" || build_exit_code=$?
+          echo "duration_seconds=$(( $(date +%s) - started_at ))" >> $GITHUB_OUTPUT
+          exit $build_exit_code
+
+      - name: Remove build secret
+        if: always()
+        run: rm -f .github_token
+
+      - name: Docker push
+        id: push
+        run: |
+          set -euo pipefail
+          image="$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG"
+          echo "size_bytes=$(docker image inspect -f '{{.Size}}' "$image")" >> $GITHUB_OUTPUT
+          started_at=$(date +%s)
+          docker push "$image"
+          echo "duration_seconds=$(( $(date +%s) - started_at ))" >> $GITHUB_OUTPUT
+          echo "image=$image" >> $GITHUB_OUTPUT
 
       - name: Update GitOps image tag
         uses: wafflestudio/waffle-world-oci/.github/actions/update-image@main
@@ -60,3 +88,30 @@ jobs:
           tag: ${{ env.IMAGE_TAG }}
           overlay-path: argocd/${{ inputs.ocir_repository }}
           private-key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+
+      # 빌드가 실패해도 어디까지 갔는지 봐야 하므로 always() 로 돌린다.
+      - name: Build timing summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## ⏱ 빌드 소요 시간 — \`${OCIR_REPOSITORY}:${IMAGE_TAG}\` (native)"
+            echo ""
+            echo "| 단계 | 소요 시간 |"
+            echo "| --- | ---: |"
+            echo "| docker build | ${{ steps.build.outputs.duration_seconds || 0 }}s |"
+            echo "| docker push | ${{ steps.push.outputs.duration_seconds || 0 }}s |"
+            echo ""
+            echo "이미지 크기: ${{ steps.push.outputs.size_bytes || 0 }} bytes"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+          .github/scripts/summarize-docker-build.sh "$DOCKER_BUILD_LOG" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload docker build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_LOG_ARTIFACT_NAME }}
+          path: ${{ env.DOCKER_BUILD_LOG }}
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -36,22 +36,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # runner 컨텍스트는 job 레벨 env 에서 못 쓰기 때문에 여기서 채운다.
+      - name: Prepare build metadata
+        run: |
+          echo "DOCKER_BUILD_LOG=${RUNNER_TEMP}/docker-build.log" >> $GITHUB_ENV
+          echo "BUILD_LOG_ARTIFACT_NAME=docker-build-log-${OCIR_REPOSITORY//\//-}-${IMAGE_TAG}" >> $GITHUB_ENV
+
       - name: Login to OCIR
         run: echo "${{ secrets.OCI_AUTH_TOKEN }}" | docker login $OCIR_REGISTRY -u ax1dvc8vmenm/members/snutt-deployer --password-stdin
 
-      - name: Docker build, tag, and push image to OCIR
-        id: build-push-image
+      # build 와 push 를 별도 스텝으로 나눠야 GitHub Actions 가 각각의 소요 시간을 따로 보여준다.
+      - name: Docker build
+        id: build
         run: |
+          set -euo pipefail
           echo "${{ github.token }}" > .github_token
+          # 빌드가 실패해도 소요 시간은 기록한다. 느려서 죽는 경우가 바로 그 정보를 봐야 하는 경우다.
+          started_at=$(date +%s)
+          build_exit_code=0
           docker build \
+            --progress=plain \
             --secret id=github_token,src=./.github_token \
             -f ${{ inputs.dockerfile }} \
             -t $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG \
             . \
-            --platform linux/arm64
-          rm -f .github_token
-          docker push $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG
-          echo "image=$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+            --platform linux/arm64 \
+            2>&1 | tee "$DOCKER_BUILD_LOG" || build_exit_code=$?
+          echo "duration_seconds=$(( $(date +%s) - started_at ))" >> $GITHUB_OUTPUT
+          exit $build_exit_code
+
+      - name: Remove build secret
+        if: always()
+        run: rm -f .github_token
+
+      - name: Docker push
+        id: push
+        run: |
+          set -euo pipefail
+          image="$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG"
+          echo "size_bytes=$(docker image inspect -f '{{.Size}}' "$image")" >> $GITHUB_OUTPUT
+          started_at=$(date +%s)
+          docker push "$image"
+          echo "duration_seconds=$(( $(date +%s) - started_at ))" >> $GITHUB_OUTPUT
+          echo "image=$image" >> $GITHUB_OUTPUT
 
       - name: Update GitOps image tag
         uses: wafflestudio/waffle-world-oci/.github/actions/update-image@main
@@ -60,3 +87,30 @@ jobs:
           tag: ${{ env.IMAGE_TAG }}
           overlay-path: argocd/${{ inputs.ocir_repository }}
           private-key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+
+      # 빌드가 실패해도 어디까지 갔는지 봐야 하므로 always() 로 돌린다.
+      - name: Build timing summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## ⏱ 빌드 소요 시간 — \`${OCIR_REPOSITORY}:${IMAGE_TAG}\` (JVM)"
+            echo ""
+            echo "| 단계 | 소요 시간 |"
+            echo "| --- | ---: |"
+            echo "| docker build | ${{ steps.build.outputs.duration_seconds || 0 }}s |"
+            echo "| docker push | ${{ steps.push.outputs.duration_seconds || 0 }}s |"
+            echo ""
+            echo "이미지 크기: ${{ steps.push.outputs.size_bytes || 0 }} bytes"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+          .github/scripts/summarize-docker-build.sh "$DOCKER_BUILD_LOG" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload docker build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_LOG_ARTIFACT_NAME }}
+          path: ${{ env.DOCKER_BUILD_LOG }}
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,24 @@ jobs:
       - name: Run Tests
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          BUILD_TIMING_LABEL: ci-test
         run: |
-          ./gradlew clean test -x processAot -x processTestAot
+          set -euo pipefail
+          ./gradlew clean test -x processAot -x processTestAot \
+            --console=plain \
+            --init-script gradle/build-timing.init.gradle \
+            2>&1 | tee "${RUNNER_TEMP}/gradle-test.log"
+
+      - name: Test timing summary
+        if: always()
+        run: |
+          set -euo pipefail
+          log="${RUNNER_TEMP}/gradle-test.log"
+          [ -f "$log" ] || exit 0
+          {
+            echo "## ⏱ 테스트 소요 시간"
+            echo ""
+            echo '```'
+            sed -n '/^BUILD TIMING \[/,/^=\{20,\}$/p' "$log" | head -100 || true
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,10 @@ FROM ghcr.io/graalvm/jdk-community:25
 WORKDIR /app
 COPY . /app
 RUN microdnf install -y findutils --nodocs
-RUN --mount=type=secret,id=github_token GITHUB_TOKEN=$(cat /run/secrets/github_token) ./gradlew :api:bootJar
+# native 빌드와 같은 계측을 붙여 둔다. JVM 빌드 시간이 native 빌드 시간의 기준선이 된다.
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    sh gradle/build-phase.sh "api:bootJar" :api:bootJar
+RUN sh gradle/build-phase.sh --summary
 EXPOSE 8080
 ENTRYPOINT java $JAVA_OPTS -jar api/build/libs/snutt-api.jar

--- a/api/Dockerfile-native
+++ b/api/Dockerfile-native
@@ -2,7 +2,25 @@
 FROM container-registry.oracle.com/graalvm/native-image:25 AS builder
 WORKDIR /app
 COPY . /app
-RUN --mount=type=secret,id=github_token GITHUB_TOKEN=$(cat /run/secrets/github_token) ./gradlew :api:nativeCompile
+
+# 빌드를 두 phase 로 나눠 각각의 소요 시간을 로그에 남긴다.
+# 이렇게 두면 BuildKit 이 레이어별 DONE 시간을 찍어주고, build-phase.sh 가 phase 요약을,
+# build-timing.init.gradle 이 태스크별 소요 시간을 찍는다.
+#
+#   compile+aot   : 의존성 해석/다운로드 + Kotlin 컴파일 + Spring AOT 처리 + AOT 생성 코드 컴파일
+#   nativeCompile : GraalVM native-image 컴파일
+#
+# aotClasses 가 nativeCompile 직전까지의 태스크를 모두 포함하므로 phase 경계로 쓴다.
+# (processAot 로 끊으면 AOT 생성 소스 컴파일이 nativeCompile phase 로 넘어가 측정이 흐려진다.)
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    sh gradle/build-phase.sh "api:compile+aot" :api:aotClasses
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    sh gradle/build-phase.sh "api:nativeCompile" :api:nativeCompile
+
+RUN sh gradle/build-phase.sh --summary
 
 # Runtime stage
 FROM docker.io/debian:stable-slim

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -2,5 +2,9 @@ FROM ghcr.io/graalvm/jdk-community:25
 WORKDIR /app
 COPY . /app
 RUN microdnf install -y findutils --nodocs
-RUN --mount=type=secret,id=github_token GITHUB_TOKEN=$(cat /run/secrets/github_token) ./gradlew :batch:bootJar
+# native 빌드와 같은 계측을 붙여 둔다. JVM 빌드 시간이 native 빌드 시간의 기준선이 된다.
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    sh gradle/build-phase.sh "batch:bootJar" :batch:bootJar
+RUN sh gradle/build-phase.sh --summary
 ENTRYPOINT java $JAVA_OPTS -jar batch/build/libs/snutt-batch.jar --job.name=${JOB_NAME}

--- a/batch/Dockerfile-native
+++ b/batch/Dockerfile-native
@@ -2,7 +2,19 @@
 FROM container-registry.oracle.com/graalvm/native-image:25 AS builder
 WORKDIR /app
 COPY . /app
-RUN --mount=type=secret,id=github_token GITHUB_TOKEN=$(cat /run/secrets/github_token) ./gradlew :batch:nativeCompile
+
+# 빌드를 두 phase 로 나눠 각각의 소요 시간을 로그에 남긴다. (api/Dockerfile-native 와 동일)
+#   compile+aot   : 의존성 해석/다운로드 + Kotlin 컴파일 + Spring AOT 처리 + AOT 생성 코드 컴파일
+#   nativeCompile : GraalVM native-image 컴파일
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    sh gradle/build-phase.sh "batch:compile+aot" :batch:aotClasses
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    sh gradle/build-phase.sh "batch:nativeCompile" :batch:nativeCompile
+
+RUN sh gradle/build-phase.sh --summary
 
 # Runtime stage
 FROM docker.io/debian:stable-slim

--- a/docs/build-timing.md
+++ b/docs/build-timing.md
@@ -1,0 +1,82 @@
+# 빌드 소요 시간 계측
+
+이 프로젝트는 런타임 메모리 사용량을 줄이기 위해 GraalVM native image 로 빌드한다.
+대신 빌드가 오래 걸리기 때문에, **어느 단계에서 시간이 드는지** CI 로그만 보고 알 수 있도록
+계측을 붙여 두었다.
+
+## 어디를 보면 되나
+
+배포 워크플로우(`_deploy.yml`, `_deploy-native.yml`)가 끝나면 **Actions 실행 화면의 Summary**에
+4단계 요약이 붙는다.
+
+| 섹션 | 알 수 있는 것 |
+| --- | --- |
+| 1. Docker 레이어별 소요 시간 | 베이스 이미지 pull / 빌드 컨텍스트 전송 / 각 RUN / 이미지 export 중 무엇이 긴지 |
+| 2. Gradle phase 별 소요 시간 | `compile+aot` 와 `nativeCompile` 의 비중 |
+| 3. Gradle 태스크별 소요 시간 | 설정·의존성 해석 시간, 그리고 개별 태스크(`compileKotlin`, `processAot`, `nativeCompile` …) 소요 시간 |
+| 4. GraalVM native-image 리포트 | native-image 에 할당된 메모리/스레드, 단계별(Analysis / Compiling code / …) 비중, Peak RSS |
+
+Summary 위쪽에는 `docker build` 와 `docker push` 각각의 소요 시간과 이미지 크기도 함께 찍힌다.
+원본 로그 전체는 같은 실행의 아티팩트 `docker-build-log-*` 로 7일간 남는다.
+
+특히 4번 섹션의 **"Build resources"** 줄을 눈여겨볼 것. GitHub 러너의 메모리가 부족하면
+native-image 가 힙을 좁게 잡고 GC 를 반복하면서 빌드 시간이 몇 배로 늘어난다.
+`Peak RSS` 와 `GC: in Xs (Y% of total time)` 이 그 신호다.
+
+## 구성 요소
+
+| 파일 | 역할 |
+| --- | --- |
+| `gradle/build-timing.init.gradle` | Gradle init script. 태스크별 소요 시간과 "첫 태스크 시작 전까지 걸린 시간"(= 설정 + 의존성 해석)을 빌드 끝에 표로 출력한다. |
+| `gradle/build-phase.sh` | Docker 빌드 안에서 gradle 을 phase 단위로 실행하고 각 phase 의 소요 시간을 누적 기록한다. `--summary` 로 최종 표를 출력한다. |
+| `.github/scripts/summarize-docker-build.sh` | `docker build` 로그에서 위 정보들을 추출해 markdown 요약을 만든다. |
+
+native Dockerfile 은 빌드를 두 phase 로 나눠 놓았다.
+
+- `compile+aot` — 의존성 해석/다운로드, Kotlin 컴파일, Spring AOT 처리, AOT 생성 코드 컴파일 (`:api:aotClasses`)
+- `nativeCompile` — GraalVM native-image 컴파일 (`:api:nativeCompile`)
+
+경계를 `aotClasses` 로 잡은 이유는, `processAot` 로 끊으면 AOT 가 생성한 소스의 컴파일이
+`nativeCompile` phase 로 넘어가 native-image 자체의 시간이 부풀려 보이기 때문이다.
+
+## 로컬에서 돌려보기
+
+태스크별 소요 시간만 보고 싶을 때:
+
+```bash
+./gradlew :api:nativeCompile --console=plain --init-script gradle/build-timing.init.gradle
+```
+
+CI 와 같은 phase 단위로 보고 싶을 때:
+
+```bash
+sh gradle/build-phase.sh "api:compile+aot" :api:aotClasses
+sh gradle/build-phase.sh "api:nativeCompile" :api:nativeCompile
+sh gradle/build-phase.sh --summary
+```
+
+Docker 빌드 로그를 직접 요약해보고 싶을 때:
+
+```bash
+docker build --progress=plain -f api/Dockerfile-native . 2>&1 | tee /tmp/docker-build.log
+.github/scripts/summarize-docker-build.sh /tmp/docker-build.log
+```
+
+### 환경변수
+
+| 이름 | 기본값 | 설명 |
+| --- | --- | --- |
+| `BUILD_TIMING_LABEL` | `gradle` | 리포트 헤더 라벨. 한 빌드에서 gradle 을 여러 번 호출할 때 구분용. |
+| `BUILD_TIMING_MIN_MILLIS` | `500` | 이 시간 미만인 태스크는 개별 행으로 출력하지 않고 합산한다. |
+| `BUILD_TIMING_OUTPUT` | (없음) | 지정하면 `소요시간(ms)<TAB>결과<TAB>태스크` TSV 를 해당 경로에 추가로 기록한다. |
+| `BUILD_PHASE_TIMING_FILE` | `build/phase-timings.tsv` | `build-phase.sh` 가 phase 기록을 쌓는 파일. |
+
+## 알아둘 것
+
+- 태스크가 병렬로 실행되면 "task time (sum)" 이 "task execution window" 보다 클 수 있다.
+  둘 다 찍는 이유가 이것이다.
+- phase 를 나누면서 gradle 을 두 번 호출하므로, 두 번째 호출의 설정 단계(수십 초)가 추가로 든다.
+  대신 native-image 시간이 다른 작업과 섞이지 않고 분리되어 보인다. 계측을 위해 치르는 비용이다.
+- 지금 Docker 빌드에는 Gradle 캐시가 없다. 매 빌드가 의존성을 새로 받는다.
+  3번 섹션의 "configuration + dependency resolution" 이 그 비용이며,
+  이 값이 크게 나온다면 캐시 도입을 검토할 근거가 된다.

--- a/gradle/build-phase.sh
+++ b/gradle/build-phase.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Docker 빌드 안에서 gradle 을 "phase" 단위로 실행하면서 각 phase 의 소요 시간을 기록한다.
+# native image 빌드가 오래 걸릴 때, 의존성 해석/컴파일/AOT/native-image 중 어디가 긴지
+# CI 로그만 보고 판단하기 위한 것이다.
+#
+# 사용법:
+#   sh gradle/build-phase.sh <phase-name> <gradle-args...>
+#   sh gradle/build-phase.sh --summary
+#
+# 환경변수:
+#   BUILD_PHASE_TIMING_FILE   phase 기록 파일 경로 (기본 build/phase-timings.tsv)
+#
+# POSIX sh 로만 작성한다. 빌더 이미지(oraclelinux 기반)에 awk 등이 없을 수 있다.
+
+set -eu
+
+timing_file="${BUILD_PHASE_TIMING_FILE:-build/phase-timings.tsv}"
+
+format_duration() {
+    seconds="$1"
+    minutes=$((seconds / 60))
+    if [ "$minutes" -gt 0 ]; then
+        printf '%dm %02ds' "$minutes" "$((seconds % 60))"
+    else
+        printf '%ds' "$seconds"
+    fi
+}
+
+print_summary() {
+    if [ ! -f "$timing_file" ]; then
+        echo "[phase] 기록된 phase 가 없습니다: $timing_file"
+        return 0
+    fi
+
+    total=0
+    while IFS='	' read -r seconds name; do
+        total=$((total + seconds))
+    done < "$timing_file"
+
+    divisor="$total"
+    if [ "$divisor" -le 0 ]; then
+        divisor=1
+    fi
+
+    echo ""
+    echo "==================== DOCKER BUILD PHASE SUMMARY ===================="
+    while IFS='	' read -r seconds name; do
+        printf '  %10s  %3d%%  %s\n' "$(format_duration "$seconds")" "$((seconds * 100 / divisor))" "$name"
+    done < "$timing_file"
+    printf '  %10s  %3d%%  %s\n' "$(format_duration "$total")" 100 "TOTAL (gradle phases)"
+    echo "===================================================================="
+    echo ""
+}
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: sh gradle/build-phase.sh <phase-name> <gradle-args...> | --summary" >&2
+    exit 2
+fi
+
+if [ "$1" = "--summary" ]; then
+    print_summary
+    exit 0
+fi
+
+phase="$1"
+shift
+
+mkdir -p "$(dirname "$timing_file")"
+
+BUILD_TIMING_LABEL="$phase"
+export BUILD_TIMING_LABEL
+
+started_at=$(date +%s)
+echo "[phase] >>> START  ${phase}  ($(date -u '+%Y-%m-%dT%H:%M:%SZ'))"
+
+./gradlew "$@" --console=plain --init-script gradle/build-timing.init.gradle
+
+elapsed=$(($(date +%s) - started_at))
+printf '%s\t%s\n' "$elapsed" "$phase" >> "$timing_file"
+echo "[phase] <<< DONE   ${phase}  ($(format_duration "$elapsed"))"

--- a/gradle/build-timing.init.gradle
+++ b/gradle/build-timing.init.gradle
@@ -1,0 +1,180 @@
+// Gradle 빌드의 태스크별 소요 시간을 측정해 빌드 종료 시 콘솔에 표로 출력한다.
+// native image 빌드가 오래 걸릴 때 어느 태스크(nativeCompile / processAot / compileKotlin ...)가
+// 시간을 쓰는지 CI 로그만 보고 판단할 수 있게 하는 것이 목적이다.
+//
+// 사용법:
+//   ./gradlew <task> --init-script gradle/build-timing.init.gradle
+//
+// 환경변수:
+//   BUILD_TIMING_LABEL       리포트 헤더에 붙는 라벨 (여러 gradle 호출을 구분할 때)
+//   BUILD_TIMING_MIN_MILLIS  이 시간 미만인 태스크는 개별 행으로 출력하지 않는다 (기본 500)
+//   BUILD_TIMING_OUTPUT      지정 시 "duration_millis<TAB>outcome<TAB>task" TSV 를 이 경로에 추가로 기록
+
+import org.gradle.api.initialization.Settings
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.build.event.BuildEventsListenerRegistry
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.gradle.tooling.events.task.TaskFailureResult
+import org.gradle.tooling.events.task.TaskFinishEvent
+import org.gradle.tooling.events.task.TaskSkippedResult
+import org.gradle.tooling.events.task.TaskSuccessResult
+
+import javax.inject.Inject
+import java.util.concurrent.ConcurrentLinkedQueue
+
+abstract class BuildTimingService
+    implements BuildService<BuildTimingService.Params>, OperationCompletionListener, AutoCloseable {
+
+    interface Params extends BuildServiceParameters {
+        Property<Long> getBuildStartedAt()
+    }
+
+    private final Queue<Map<String, Object>> records = new ConcurrentLinkedQueue<>()
+
+    @Override
+    void onFinish(FinishEvent event) {
+        if (!(event instanceof TaskFinishEvent)) {
+            return
+        }
+        def result = event.result
+        records.add([
+            path    : event.descriptor.taskPath,
+            startedAt: result.startTime,
+            finishedAt: result.endTime,
+            duration: result.endTime - result.startTime,
+            outcome : describeOutcome(result),
+        ])
+    }
+
+    static String describeOutcome(result) {
+        if (result instanceof TaskSuccessResult) {
+            if (result.upToDate) {
+                return 'UP-TO-DATE'
+            }
+            if (result.fromCache) {
+                return 'FROM-CACHE'
+            }
+            return 'EXECUTED'
+        }
+        if (result instanceof TaskSkippedResult) {
+            return 'SKIPPED'
+        }
+        if (result instanceof TaskFailureResult) {
+            return 'FAILED'
+        }
+        return 'UNKNOWN'
+    }
+
+    @Override
+    void close() {
+        def wallMillis = System.currentTimeMillis() - parameters.buildStartedAt.get()
+        def sorted = records.toList().sort { -it.duration }
+        def totalTaskMillis = sorted.sum { it.duration } ?: 0L
+        def label = System.getenv('BUILD_TIMING_LABEL') ?: 'gradle'
+        def minMillis = (System.getenv('BUILD_TIMING_MIN_MILLIS') ?: '500') as long
+
+        def report = new StringBuilder()
+        report.append('\n')
+        report.append('=' * 78).append('\n')
+        report.append("BUILD TIMING [${label}]\n")
+        report.append("  gradle wall time : ${formatSeconds(wallMillis)}\n")
+        if (!sorted.isEmpty()) {
+            // 첫 태스크가 시작되기 전까지 = 설정 단계 + 의존성 해석/다운로드.
+            // 태스크가 병렬로 돌아도 정확한 값이라 sum 과 wall time 의 차이보다 신뢰할 만하다.
+            def beforeFirstTaskMillis = sorted.min { it.startedAt }.startedAt - parameters.buildStartedAt.get()
+            def taskWindowMillis = sorted.max { it.finishedAt }.finishedAt - sorted.min { it.startedAt }.startedAt
+            report.append("  configuration + dependency resolution : ${formatSeconds(beforeFirstTaskMillis)}\n")
+            report.append("  task execution window                 : ${formatSeconds(taskWindowMillis)}\n")
+        }
+        report.append("  task time (sum)  : ${formatSeconds(totalTaskMillis)} (병렬 실행 시 window 보다 클 수 있음)\n")
+        report.append("  tasks            : ${sorted.size()} (executed ${sorted.count { it.outcome == 'EXECUTED' }})\n")
+        report.append('-' * 78).append('\n')
+        report.append(String.format('%9s %6s  %-11s %s%n', 'DURATION', 'SHARE', 'OUTCOME', 'TASK'))
+
+        def shown = 0
+        def hiddenMillis = 0L
+        sorted.each { record ->
+            if (record.duration < minMillis) {
+                hiddenMillis += record.duration
+                return
+            }
+            shown++
+            def share = totalTaskMillis > 0 ? (record.duration * 100.0d / totalTaskMillis) : 0.0d
+            report.append(String.format(
+                '%9s %5.1f%%  %-11s %s%n',
+                formatSeconds(record.duration), share, record.outcome, record.path,
+            ))
+        }
+        if (shown == 0) {
+            report.append("  (${minMillis}ms 이상 걸린 태스크 없음)\n")
+        }
+        if (hiddenMillis > 0) {
+            report.append(String.format(
+                '%9s %6s  %-11s %s%n',
+                formatSeconds(hiddenMillis), '', '',
+                "그 외 ${sorted.size() - shown}개 태스크 (< ${minMillis}ms)",
+            ))
+        }
+        report.append('=' * 78).append('\n')
+
+        // System.out 으로 직접 쓴다. 이 시점에는 Gradle logger 가 이미 닫혀 있을 수 있다.
+        System.out.print(report.toString())
+        System.out.flush()
+
+        writeTsv(sorted)
+    }
+
+    void writeTsv(List<Map<String, Object>> sorted) {
+        def outputPath = System.getenv('BUILD_TIMING_OUTPUT')
+        if (!outputPath) {
+            return
+        }
+        try {
+            def file = new File(outputPath)
+            file.parentFile?.mkdirs()
+            file.withWriterAppend('UTF-8') { writer ->
+                sorted.each { record ->
+                    writer.writeLine("${record.duration}\t${record.outcome}\t${record.path}")
+                }
+            }
+        } catch (Exception exception) {
+            System.err.println("[build-timing] TSV 기록 실패 (${outputPath}): ${exception.message}")
+        }
+    }
+
+    static String formatSeconds(long millis) {
+        return String.format('%.2fs', millis / 1000.0d)
+    }
+}
+
+abstract class BuildTimingPlugin implements Plugin<Settings> {
+
+    @Inject
+    abstract BuildEventsListenerRegistry getBuildEventsListenerRegistry()
+
+    @Override
+    void apply(Settings settings) {
+        // 아래 settingsEvaluated 에서 이미 등록해 두었으므로 여기서는 그 인스턴스를 돌려받는다.
+        // (BuildEventsListenerRegistry 는 @Inject 로만 얻을 수 있어서 플러그인이 필요하다.)
+        def service = settings.gradle.sharedServices.registerIfAbsent(
+            'buildTiming', BuildTimingService,
+        ) {}
+        buildEventsListenerRegistry.onTaskCompletion(service)
+    }
+}
+
+// 이 init script 는 빌드마다 새로 실행되므로 여기서 시각을 잡아야 한다.
+// 클래스의 static 필드에 담으면 Gradle 데몬이 클래스를 재사용하면서 첫 빌드 시각이 그대로 남는다.
+def buildStartedAt = System.currentTimeMillis()
+
+settingsEvaluated { settings ->
+    settings.gradle.sharedServices.registerIfAbsent(
+        'buildTiming', BuildTimingService,
+    ) { spec ->
+        spec.parameters.buildStartedAt.set(buildStartedAt)
+    }
+    settings.pluginManager.apply(BuildTimingPlugin)
+}


### PR DESCRIPTION
## Goal
- native image 빌드가 왜 오래 걸리는지 CI 로그만 보고 판단할 수 있게 한다. 최적화에 손대기 전에 근거를 먼저 확보하는 단계다.

## 문제 or 요구 사항
- 런타임 메모리를 줄이려고 native image 로 빌드하고 있고, 그 대가로 빌드가 오래 걸린다. 그런데 지금은 **어디서** 시간이 드는지 알 방법이 없다.
- `docker build` 와 `docker push` 가 한 스텝에 묶여 있어 둘 중 무엇이 느린지 구분되지 않고, Dockerfile 의 `RUN ./gradlew :api:nativeCompile` 한 줄이 의존성 다운로드 · Kotlin 컴파일 · Spring AOT · native-image 컴파일을 전부 삼킨다. BuildKit 기본 progress 라 베이스 이미지 pull 시간도 남지 않는다.
- 결과적으로 "빌드가 느리다" 외에는 정보가 없어서, 최적화를 어디부터 손대야 하는지 판단할 근거가 없었다.

## 변경 사항
- **native 빌드를 두 단계로 분리.** 컴파일·AOT 처리까지와 native-image 컴파일을 나눠서, native-image 자체가 실제로 얼마를 쓰는지 다른 작업과 섞이지 않게 했습니다.
- **Gradle 태스크별 소요 시간 출력.** 태스크별 시간과 "첫 태스크가 시작되기 전까지 걸린 시간"(= 설정 + 의존성 해석)을 빌드 끝에 표로 남깁니다.
- **결과를 Actions Summary 로 끌어올림.** 수천 줄 로그를 뒤지지 않도록 레이어별 시간 / 단계별 비중 / 태스크별 시간 / GraalVM 자체 리포트 네 가지를 요약해 붙입니다. 원본 로그는 아티팩트로 7일 보관.
- **build 와 push 를 별도 스텝으로 분리.** 스텝이 나뉘어야 Actions 가 각각의 시간을 따로 보여줍니다. 빌드가 실패해도 소요 시간은 기록되게 했습니다.
- JVM Dockerfile 과 테스트 CI 에도 같은 계측을 붙여, native 빌드 시간을 비교할 기준선을 만들었습니다.

## 이어서 볼 것
- **아직 검증 안 된 것:** native Dockerfile 의 전체 end-to-end 빌드. 로컬에서 30~60분이 걸려 완주하지 못했습니다. 구성 요소는 개별로 검증했지만(아래) 두 단계가 컨테이너 안에서 실제로 이어 도는 것은 첫 CI 실행이 검증입니다. **dev 배포로 먼저 확인한 뒤 prod 에 태우는 것을 권합니다.**
- **검증한 것:** init script 를 실제 빌드에 적용해 태스크 시간 측정 확인, 태스크 그래프 dry-run 으로 단계 경계 타당성 확인, 합성 로그로 Summary 4개 섹션 파싱 확인(빈 로그·로그 없음 포함), 셸 스크립트를 dash 와 Oracle Linux 9 에서 실행 확인, 워크플로우 YAML 파싱과 `spotlessCheck` 통과.
- **측정한 다음에 판단할 것:**
  - Docker 빌드에 Gradle 캐시가 없어 매 빌드가 의존성을 새로 받습니다. Summary 의 "configuration + dependency resolution" 값이 그 비용이라, 이 값이 크면 캐시 도입의 근거가 됩니다. 이번 PR 은 계측이 목적이라 최적화는 의도적으로 손대지 않았습니다.
  - GraalVM 리포트의 Build resources 와 Peak RSS. 러너 메모리가 부족하면 native-image 가 GC 를 반복하며 빌드가 크게 느려지므로 첫 번째 의심 지점입니다.
- 단계 경계를 `aotClasses` 로 잡은 이유: `processAot` 로 끊으면 AOT 가 생성한 소스의 컴파일이 native 단계로 넘어가 native-image 시간이 부풀려 보입니다.
- 읽는 법과 로컬 재현 방법은 `docs/build-timing.md` 에 정리해 두었습니다.

## Screenshot

## Reference
- 테크스펙
- 스펙 문서
- Figma
- 논의 슬랙