### PR TITLE
영문 교수명 검색에서 구분자 무시하고 매칭

### DIFF
--- a/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
+++ b/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
@@ -150,7 +150,7 @@ class LectureCustomRepositoryImpl(
                         Lecture::courseTitle.regex(Regex.escape(keyword), "i"),
                         Lecture::courseTitleEn.regex(Regex.escape(keyword), "i"),
                         Lecture::instructor.regex(Regex.escape(keyword), "i"),
-                        Lecture::instructorEn.regex(Regex.escape(keyword), "i"),
+                        Lecture::instructorEn.regex(keyword.toInstructorEnPattern(), "i"),
                         Lecture::courseNumber isEqualTo keyword,
                         Lecture::lectureNumber isEqualTo keyword,
                     )
@@ -241,6 +241,18 @@ class LectureCustomRepositoryImpl(
                 }
             },
         )
+
+    /*
+    영문 교수명 표기가 'Han, Chul-woong', 'Lee Ho Young', 'Park,  YoonJeong', 'AN/YOONGSOO'처럼 제각각이라
+    구분자(공백/쉼표/하이픈/슬래시)를 무시하고 매칭한다. 다만 노이즈를 줄이기 위해 이름 단어 첫 글자부터
+    시작하는 매치만 허용한다.
+     */
+    private fun String.toInstructorEnPattern(): String {
+        val separator = "[^A-Za-z0-9가-힣]"
+        val letters = filter { it.isLetterOrDigit() }
+        if (letters.isEmpty()) return Regex.escape(this)
+        return letters.toCharArray().joinToString("$separator*", prefix = "(?:^|$separator)") { Regex.escape(it.toString()) }
+    }
 
     private fun Char.isKoreanLetter(): Boolean = this in '가'..'힣'
 


### PR DESCRIPTION
## 문제

EN 검색의 영문 교수명 매칭이 `Regex.escape(keyword)` 단순 부분문자열이라, 수강신청 데이터의 표기 난립을 따라가지 못한다.

2026-2학기 영문 엑셀 기준 고유 교수명 3,199개를 보면 `Han, Chul-woong`(콤마 표기 1,167개), `Lee Ho Young`, `Park,  YoonJeong`(연속 공백 216개), `AN/YOONGSOO`, `LEE SANGHWA`가 섞여 있고 성-이름 순서도 제각각이다.

그래서 사용자가 이름을 공백 없이 붙여서 입력하면 검색이 잘 되지 않는다.

- `chulwoong` → `Han, Chul-woong` 못 찾음
- `kunsoo` → `Park, Kun Soo` 못 찾음
- `namhyuk` → `CHO, NAM  HYUK` 못 찾음
- `jaehyeung` → `Jae-Hyeung Park` 못 찾음
- `song yoonkyu` → `Song, Yoon-Kyu` 못 찾음. `song yoon kyu`로 하이픈 위치를 정확히 맞춰 띄어 써야만 나온다.

## 변경

- `instructor_en` 매칭 시 구분자(공백/쉼표/하이픈/슬래시 등 영숫자·한글이 아닌 모든 문자)를 무시하도록 검색어를 문자 단위 패턴으로 변환한다.
- 단순 부분문자열로 풀면 노이즈가 커지므로(`hoyoung`이 `CHO, YOUNGTAE`에 매칭됨) **이름 단어의 첫 글자부터 시작하는 매치만** 허용하도록 패턴 앞에 경계 조건을 붙였다.

## 효과

고유 영문 교수명 3,199개 중 매칭되는 이름 수:

| 검색어 | 변경 전 | 변경 후 |
| --- | --- | --- |
| `chulwoong` | 0 | 1 |
| `song yoonkyu` | 0 | 1 |
| `kunsoo` | 0 | 1 |
| `namhyuk` | 0 | 1 |
| `jaehyeung` | 0 | 1 |
| `eunhui` | 0 | 1 |
| `eekyung` | 2 (전부 오탐) | 1 |
| `an` | 705 | 12 |
| `han` | 190 | 82 |

`eekyung`은 변경 전후 결과가 서로소다. 기존에는 `Ee-Kyung Kim`을 못 찾으면서 `Joh HeeKyung`, `Park,  Heekyung`을 반환했고,
변경 후에는 `Ee-Kyung Kim`만 나온다.

**`Chulwoong Han`처럼 성-이름 순서를 바꿔 입력해도 검색어가 공백 단위로 AND 매칭되므로 정상 동작한다.**

## 범위 밖

- 한글 `instructor` 폴백은 그대로 둔다. 한글 이름은 구분자가 없어 경계 조건을 걸면 "철웅"으로 "한철웅"을 못 찾게 된다.
- `course_title_en`과 KO 검색 경로는 손대지 않았다.
- camelCase 경계(`Kim, JungWook`을 `wook`으로 검색)는 미지원. 