### PR TITLE
강의검색 정렬 기준 영문 응답 지원

### DIFF
--- a/core/src/main/kotlin/common/enums/SortCriteria.kt
+++ b/core/src/main/kotlin/common/enums/SortCriteria.kt
@@ -13,17 +13,19 @@ enum class SortCriteria(
     val value: Int,
     @JsonValue
     val fullName: String,
+    val fullNameEn: String,
 ) {
-    ID(1, "기본값"),
-    RATING_DESC(2, "평점 높은 순"),
-    COUNT_DESC(3, "강의평 많은 순"),
+    ID(1, "기본값", "Default"),
+    RATING_DESC(2, "평점 높은 순", "Highest rating"),
+    COUNT_DESC(3, "강의평 많은 순", "Most reviews"),
     ;
 
-    // RATING_ASC(4, "평점 낮은 순"),
-    // COUNT_ASC(5, "강의평 적은 순");
+    // RATING_ASC(4, "평점 낮은 순", "Lowest rating"),
+    // COUNT_ASC(5, "강의평 적은 순", "Fewest reviews");
 
     companion object {
-        private val nameMap = entries.associateBy { it.fullName }
+        // 클라이언트가 언어에 따라 한글/영문 중 무엇을 보내든 받을 수 있도록 둘 다 키로 등록한다.
+        private val nameMap = entries.flatMap { listOf(it.fullName to it, it.fullNameEn to it) }.toMap()
 
         fun getOfName(sortCriteriaName: String?): SortCriteria? = nameMap[sortCriteriaName]
 

--- a/core/src/main/kotlin/tag/data/TagListResponse.kt
+++ b/core/src/main/kotlin/tag/data/TagListResponse.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt.tag.data
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snutt.common.client.Language
+import com.wafflestudio.snutt.common.client.select
 import com.wafflestudio.snutt.common.enums.SortCriteria
 
 data class TagListResponse(
@@ -37,8 +38,8 @@ fun TagListResponse(
         sortCriteria =
             SortCriteria.entries
                 .sortedBy { it.value }
-                .map { it.fullName }
-                .filterNot { it == "기본값" },
+                .filterNot { it == SortCriteria.ID }
+                .map { language.select(it.fullName, it.fullNameEn) },
         updatedAt = tagList.updatedAt.toEpochMilli(),
         categoryPre2025 = tagList.tagCollection.categoryPre2025,
     )


### PR DESCRIPTION
## 변경 사항

강의검색 정렬 기준(`평점 높은 순`, `강의평 많은 순`)을 EN 클라이언트에는 영문으로 내려줍니다.

- `GET /v1/tags/{year}/{semester}`: 언어에 따라 `Highest rating` / `Most reviews`로 응답합니다. 다른 태그들과 동일하게 `Language.select`를 씁니다. `기본값` 항목을 목록에서 제외하던 조건은 문자열 비교였어서, enum 비교로 바꿨습니다.
- `POST /v1/search_query`: `SortCriteria.getOfName`이 한글·영문 이름을 모두 받도록 했습니다. 클라이언트가 태그 API에서 받은 문자열을 그대로 돌려보내는 구조라 이게 없으면 영문 값이 `Sort.unsorted()`로 조용히 떨어집니다. 구버전 앱이 보내는 한글 값도 그대로 동작합니다.
