### PR TITLE
구 교양영역 영문 응답 지원

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -207,6 +207,7 @@ class SugangSnuSyncServiceImpl(
                                 .filterNotNull()
                                 .filter { it.isNotBlank() }
                                 .sorted(),
+                        creditEn = parsedTag.credit.sorted().map { if (it == 1L) "1 credit" else "$it credits" },
                         classificationEn =
                             parsedTag.classificationEn
                                 .filterNotNull()

--- a/core/src/main/kotlin/common/enums/LectureCategoryPre2025.kt
+++ b/core/src/main/kotlin/common/enums/LectureCategoryPre2025.kt
@@ -1,0 +1,56 @@
+package com.wafflestudio.snutt.common.enums
+
+import com.wafflestudio.snutt.common.client.Language
+import com.wafflestudio.snutt.common.client.select
+
+/**
+ * 2025 교양 개편 이전 교양영역(구 교양영역).
+ *
+ * 수강신청 엑셀이 아니라 batch의 categoryPre2025.txt(과목번호 → 한글)에서 오는 값이라
+ * Lecture에 영문 필드가 따로 없다. 그래서 DB에는 한글만 저장하고 응답/요청 경계에서 양방향으로 변환한다.
+ * 한글 표기는 categoryPre2025.txt, 영문 표기는 수강신청 공통코드(SBJT_FLD)를 따른다.
+ */
+enum class LectureCategoryPre2025(
+    val fullName: String,
+    val fullNameEn: String,
+) {
+    // 학문의 기초
+    FOUNDATION_WRITING("사고와 표현", "Critical Thinking and Writing"),
+    FOUNDATION_LANGUAGE("외국어", "Foreign Languages"),
+    FOUNDATION_MATH("수량적 분석과 추론", "Mathematical Sciences"),
+    FOUNDATION_SCIENCE("과학적 사고와 실험", "Natural Sciences"),
+    FOUNDATION_COMPUTER("컴퓨터와 정보 활용", "Computer and Information Science"),
+
+    // 학문의 세계
+    KNOWLEDGE_LITERATURE("언어와 문학", "Language and Literature"),
+    KNOWLEDGE_ART("문화와 예술", "Culture and Art"),
+    KNOWLEDGE_HISTORY("역사와 철학", "History and Philosophy"),
+    KNOWLEDGE_POLITICS("정치와 경제", "Politics and Economy"),
+    KNOWLEDGE_HUMAN("인간과 사회", "Humans and Society"),
+    KNOWLEDGE_NATURE("자연과 기술", "Nature and Technology"),
+    KNOWLEDGE_LIFE("생명과 환경", "Life and Environment"),
+
+    // 선택교양
+    GENERAL_PHYSICAL("체육", "Physical Education"),
+    GENERAL_ART("예술 실기", "Art Practice"),
+    GENERAL_COLLEGE("대학과 리더십", "College Life and Leadership"),
+    GENERAL_CREATIVITY("창의와 융합", "Creativity and Convergence"),
+    GENERAL_KOREAN("한국의 이해", "Korea in the World (Courses in English)"),
+    ;
+
+    companion object {
+        // 클라이언트가 언어에 따라 한글/영문 중 무엇을 보내든 받을 수 있도록 둘 다 키로 등록한다.
+        private val nameMap = entries.flatMap { listOf(it.fullName to it, it.fullNameEn to it) }.toMap()
+
+        fun getOfName(categoryName: String?): LectureCategoryPre2025? = nameMap[categoryName]
+
+        /** 응답용. DB의 한글 값을 요청 언어에 맞춰 바꾼다. 매핑에 없는 값은 원본을 그대로 둔다. */
+        fun localize(
+            categoryName: String,
+            language: Language,
+        ): String = language.select(categoryName, getOfName(categoryName)?.fullNameEn)
+
+        /** 요청용. 한글/영문 어느 쪽으로 들어와도 DB에 저장·조회할 한글 값으로 되돌린다. */
+        fun toKorean(categoryName: String): String = getOfName(categoryName)?.fullName ?: categoryName
+    }
+}

--- a/core/src/main/kotlin/lectures/dto/LectureDto.kt
+++ b/core/src/main/kotlin/lectures/dto/LectureDto.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.lectures.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.client.select
+import com.wafflestudio.snutt.common.enums.LectureCategoryPre2025
 import com.wafflestudio.snutt.common.enums.Semester
 import com.wafflestudio.snutt.evaluation.dto.SnuttEvLectureSummaryDto
 import com.wafflestudio.snutt.lectures.data.Lecture
@@ -61,5 +62,5 @@ fun LectureDto(
         registrationCount = lecture.registrationCount,
         wasFull = lecture.wasFull,
         snuttEvLecture = snuttevLecture,
-        categoryPre2025 = lecture.categoryPre2025,
+        categoryPre2025 = lecture.categoryPre2025?.let { LectureCategoryPre2025.localize(it, language) },
     )

--- a/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
+++ b/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt.lectures.repository
 
 import com.wafflestudio.snutt.common.client.Language
+import com.wafflestudio.snutt.common.enums.LectureCategoryPre2025
 import com.wafflestudio.snutt.common.enums.SortCriteria
 import com.wafflestudio.snutt.common.extension.isEqualTo
 import com.wafflestudio.snutt.lectures.data.ClassPlaceAndTime
@@ -73,7 +74,8 @@ class LectureCustomRepositoryImpl(
                                     searchCondition.categoryPre2025
                                         ?.takeIf {
                                             it.isNotEmpty()
-                                        }?.let { Lecture::categoryPre2025 inValues it },
+                                        }?.map { LectureCategoryPre2025.toKorean(it) }
+                                        ?.let { Lecture::categoryPre2025 inValues it },
                                 ).takeIf { it.isNotEmpty() }?.let {
                                     Criteria().orOperator(it)
                                 },

--- a/core/src/main/kotlin/tag/data/TagList.kt
+++ b/core/src/main/kotlin/tag/data/TagList.kt
@@ -39,6 +39,8 @@ data class TagCollection(
     val departmentEn: List<String> = listOf(),
     @Field("academic_year_en")
     val academicYearEn: List<String> = listOf(),
+    @Field("credit_en")
+    val creditEn: List<String> = listOf(),
     @Field("instructor_en")
     val instructorEn: List<String> = listOf(),
     @Field("category_en")

--- a/core/src/main/kotlin/tag/data/TagListResponse.kt
+++ b/core/src/main/kotlin/tag/data/TagListResponse.kt
@@ -33,7 +33,7 @@ fun TagListResponse(
         classification = localize(tagList.tagCollection.classification, tagList.tagCollection.classificationEn),
         department = localize(tagList.tagCollection.department, tagList.tagCollection.departmentEn),
         academicYear = localize(tagList.tagCollection.academicYear, tagList.tagCollection.academicYearEn),
-        credit = tagList.tagCollection.credit,
+        credit = localize(tagList.tagCollection.credit, tagList.tagCollection.creditEn),
         instructor = localize(tagList.tagCollection.instructor, tagList.tagCollection.instructorEn),
         category = localize(tagList.tagCollection.category, tagList.tagCollection.categoryEn),
         sortCriteria =

--- a/core/src/main/kotlin/tag/data/TagListResponse.kt
+++ b/core/src/main/kotlin/tag/data/TagListResponse.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.tag.data
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.client.select
+import com.wafflestudio.snutt.common.enums.LectureCategoryPre2025
 import com.wafflestudio.snutt.common.enums.SortCriteria
 
 data class TagListResponse(
@@ -41,6 +42,9 @@ fun TagListResponse(
                 .filterNot { it == SortCriteria.ID }
                 .map { language.select(it.fullName, it.fullNameEn) },
         updatedAt = tagList.updatedAt.toEpochMilli(),
-        categoryPre2025 = tagList.tagCollection.categoryPre2025,
+        categoryPre2025 =
+            tagList.tagCollection.categoryPre2025.map {
+                LectureCategoryPre2025.localize(it, language)
+            },
     )
 }

--- a/core/src/main/kotlin/timetables/dto/TimetableLectureDto.kt
+++ b/core/src/main/kotlin/timetables/dto/TimetableLectureDto.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.timetables.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snutt.common.client.Language
 import com.wafflestudio.snutt.common.client.select
+import com.wafflestudio.snutt.common.enums.LectureCategoryPre2025
 import com.wafflestudio.snutt.evaluation.dto.SnuttEvLectureIdDto
 import com.wafflestudio.snutt.lectures.dto.ClassPlaceAndTimeDto
 import com.wafflestudio.snutt.lectures.dto.ClassPlaceAndTimeLegacyDto
@@ -54,7 +55,7 @@ fun TimetableLectureDto(
     colorIndex = timetableLecture.colorIndex,
     lectureId = timetableLecture.lectureId,
     snuttEvLecture = snuttEvLecture,
-    categoryPre2025 = timetableLecture.categoryPre2025,
+    categoryPre2025 = timetableLecture.categoryPre2025?.let { LectureCategoryPre2025.localize(it, language) },
 )
 
 data class TimetableLectureLegacyDto(
@@ -110,5 +111,5 @@ fun TimetableLectureLegacyDto(
     colorIndex = timetableLecture.colorIndex,
     lectureId = timetableLecture.lectureId,
     snuttEvLecture = snuttEvLecture,
-    categoryPre2025 = timetableLecture.categoryPre2025,
+    categoryPre2025 = timetableLecture.categoryPre2025?.let { LectureCategoryPre2025.localize(it, language) },
 )

--- a/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.timetables.service
 
+import com.wafflestudio.snutt.common.enums.LectureCategoryPre2025
 import com.wafflestudio.snutt.common.exception.CustomLectureResetException
 import com.wafflestudio.snutt.common.exception.DuplicateTimetableLectureException
 import com.wafflestudio.snutt.common.exception.InvalidTimeException
@@ -146,7 +147,9 @@ class TimetableLectureServiceImpl(
             color = modifyTimetableLectureRequestDto.color ?: color
             colorIndex = modifyTimetableLectureRequestDto.colorIndex ?: colorIndex
             classPlaceAndTimes = newClassPlaceAndTimes
-            categoryPre2025 = modifyTimetableLectureRequestDto.categoryPre2025 ?: categoryPre2025
+            categoryPre2025 =
+                modifyTimetableLectureRequestDto.categoryPre2025
+                    ?.let { LectureCategoryPre2025.toKorean(it) } ?: categoryPre2025
         }
         resolveTimeConflict(timetable, timetableLecture, isForced)
         return timetableRepository.updateTimetableLecture(timetableId, timetableLecture).also {


### PR DESCRIPTION
## 변경 사항

구 교양영역(`categoryPre2025`)을 EN 클라이언트에는 영문으로 내려줍니다.

이 값은 수강신청 엑셀이 아니라 batch의 `categoryPre2025.txt`(과목번호 → 한글)에서 오는 거라 `Lecture`에 영문 필드가 없습니다. `categoryPre2025En` 같은 필드를 새로 두는 대신, DB에는 계속 한글만 저장하고 응답/요청 경계에서 양방향 변환합니다. 값이 17개로 고정이고 수강신청 공통코드(`SBJT_FLD` 40~56)와 1:1로 대응해서 매핑 테이블로 충분합니다.

- `LectureCategoryPre2025` enum 추가. 한글 표기는 `categoryPre2025.txt`, 영문 표기는 공통코드를 따릅니다. `SortCriteria`와 동일하게 한/영 양쪽을 키로 갖는 맵이라 클라이언트가 어느 쪽을 보내도 받습니다.
- **응답 ko → en**: 태그 목록, `LectureDto`, `TimetableLectureDto`(신규/레거시). 지금까지 이 필드만 `language.select`를 안 타서, EN 응답에 `"category": "Humanities"`와 `"categoryPre2025": "언어와 문학"`이 섞여 나갔습니다.
- **요청 en → ko**: 검색 필터와 시간표 강의 수정. 검색은 `$in` 완전 일치라 역매핑이 없으면 영문 필터가 0건이 되고, 수정 API는 클라가 받은 값을 그대로 돌려보내 DB에 쓰는 경로라 정규화하지 않으면 영문이 저장됩니다.

`categoryPre2025.txt`의 고유값 17개가 enum과 정확히 일치하는지, 영문명에 중복이 없는지(역매핑이 모호해지지 않도록) 확인했습니다.

## 참고

`batch`의 `LectureCategory` enum은 같은 목록을 들고 있지만 레포 전체에서 참조가 0건인 죽은 코드고, 표기도 txt와 어긋나 있어(`예술실기`, `대학과 리더쉽`) 재사용하지 않았습니다.
