### PR TITLE
친구 목록 조회 API 요청/응답 진단 로그 추가

### DIFF
--- a/api/src/main/kotlin/controller/FriendController.kt
+++ b/api/src/main/kotlin/controller/FriendController.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.snutt.controller
 
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.dto.ListResponse
 import com.wafflestudio.snutt.config.CurrentUser
+import com.wafflestudio.snutt.debug.service.FriendListDebugService
 import com.wafflestudio.snutt.filter.SnuttDefaultApiFilterTarget
 import com.wafflestudio.snutt.friend.dto.FriendRequest
 import com.wafflestudio.snutt.friend.dto.FriendRequestLinkResponse
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -32,11 +35,18 @@ import org.springframework.web.bind.annotation.RestController
 class FriendController(
     private val friendService: FriendService,
     private val userNicknameService: UserNicknameService,
+    private val friendListDebugService: FriendListDebugService,
 ) {
     @GetMapping("")
     suspend fun getFriends(
         @CurrentUser user: User,
         @RequestParam state: String,
+        @RequestAttribute("clientInfo") clientInfo: ClientInfo,
+    ): ListResponse<FriendResponse> = friendListDebugService.capture(user, state, clientInfo) { getFriendList(user, state) }
+
+    private suspend fun getFriendList(
+        user: User,
+        state: String,
     ): ListResponse<FriendResponse> {
         val userId = user.id!!
         val friendState = FriendState.from(state) ?: throw IllegalArgumentException("Invalid state")

--- a/core/src/main/kotlin/debug/data/FriendListDebugLog.kt
+++ b/core/src/main/kotlin/debug/data/FriendListDebugLog.kt
@@ -1,0 +1,36 @@
+package com.wafflestudio.snutt.debug.data
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+
+/**
+ * 친구 목록 조회 API(GET /v1/friends)의 요청/응답을 그대로 남겨 두기 위한 임시 진단용 컬렉션.
+ *
+ * 파드가 자주 재시작되어 애플리케이션 로그가 유실되는 상황이라 DB 에 적재한다.
+ * userId 는 조회 편의를 위해 ObjectId 가 아닌 문자열로 저장한다.
+ * 원인 파악이 끝나면 이 커밋을 되돌려 debug 패키지와 호출부를 함께 제거한다.
+ */
+@Document("friend_list_debug_logs")
+data class FriendListDebugLog(
+    @Id
+    val id: String? = null,
+    @Indexed
+    val requesterUserId: String,
+    val requesterNickname: String,
+    /** state 요청 파라미터 원본. FriendState 로 파싱되지 않으면 500 이 난다. */
+    val state: String,
+    val osType: String,
+    val appVersion: String?,
+    val success: Boolean,
+    /** 성공 시 응답 본문 JSON 전문. 직렬화에 실패하면 null */
+    val responseJson: String?,
+    val friendCount: Int?,
+    val errorClass: String?,
+    val errorMessage: String?,
+    /** 예상 못 한 예외의 발생 지점 확인용. 4000자에서 자른다. */
+    val stackTrace: String?,
+    @Indexed(expireAfter = "14d")
+    val createdAt: Instant = Instant.now(),
+)

--- a/core/src/main/kotlin/debug/repository/FriendListDebugLogRepository.kt
+++ b/core/src/main/kotlin/debug/repository/FriendListDebugLogRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.snutt.debug.repository
+
+import com.wafflestudio.snutt.debug.data.FriendListDebugLog
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface FriendListDebugLogRepository : CoroutineCrudRepository<FriendListDebugLog, String>

--- a/core/src/main/kotlin/debug/service/FriendListDebugService.kt
+++ b/core/src/main/kotlin/debug/service/FriendListDebugService.kt
@@ -1,0 +1,80 @@
+package com.wafflestudio.snutt.debug.service
+
+import com.wafflestudio.snutt.common.client.ClientInfo
+import com.wafflestudio.snutt.common.dto.ListResponse
+import com.wafflestudio.snutt.debug.data.FriendListDebugLog
+import com.wafflestudio.snutt.debug.repository.FriendListDebugLogRepository
+import com.wafflestudio.snutt.friend.dto.FriendResponse
+import com.wafflestudio.snutt.users.data.User
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * 친구 목록 조회 API의 모든 호출을 [FriendListDebugLog] 로 남기는 임시 진단용 서비스.
+ * 원인 파악이 끝나면 이 커밋을 되돌려 제거한다.
+ */
+@Service
+class FriendListDebugService(
+    private val friendListDebugLogRepository: FriendListDebugLogRepository,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * [block] 의 요청/응답(또는 예외)을 DB 에 남긴다.
+     * 기록 과정에서 발생하는 예외는 모두 삼켜 API 응답에 영향을 주지 않는다.
+     */
+    suspend fun capture(
+        user: User,
+        state: String,
+        clientInfo: ClientInfo,
+        block: suspend () -> ListResponse<FriendResponse>,
+    ): ListResponse<FriendResponse> {
+        val result =
+            try {
+                block()
+            } catch (e: Throwable) {
+                // 클라이언트 연결이 끊겨 코루틴이 취소된 경우에도 기록은 남긴다.
+                withContext(NonCancellable) { record(user, state, clientInfo, null, e) }
+                throw e
+            }
+
+        record(user, state, clientInfo, result, null)
+        return result
+    }
+
+    private suspend fun record(
+        user: User,
+        state: String,
+        clientInfo: ClientInfo,
+        result: ListResponse<FriendResponse>?,
+        throwable: Throwable?,
+    ) {
+        runCatching {
+            friendListDebugLogRepository.save(
+                FriendListDebugLog(
+                    requesterUserId = user.id!!,
+                    requesterNickname = user.nickname,
+                    state = state,
+                    osType = clientInfo.osType.name,
+                    appVersion = clientInfo.appVersion?.appVersion,
+                    success = throwable == null,
+                    responseJson = result?.let(::toJsonOrNull),
+                    friendCount = result?.totalCount,
+                    errorClass = throwable?.let { it::class.qualifiedName },
+                    errorMessage = throwable?.message,
+                    stackTrace = throwable?.stackTraceToString()?.take(STACK_TRACE_MAX_LENGTH),
+                ),
+            )
+        }.onFailure { log.warn("친구 목록 진단 로그 저장 실패 (userId: ${user.id})", it) }
+    }
+
+    private fun toJsonOrNull(value: Any): String? = runCatching { objectMapper.writeValueAsString(value) }.getOrNull()
+
+    companion object {
+        private const val STACK_TRACE_MAX_LENGTH = 4000
+    }
+}


### PR DESCRIPTION
## 문제

친구 목록이 안 뜬다는 제보가 있는데, 현재 서버 로그로는 확인이 안 됩니다.

## 변경 사항

`GET /v1/friends` 호출의 요청/응답(또는 예외)을 `friend_list_debug_logs` 컬렉션에 그대로 적재합니다. 대상 계정을 가리지 않고 전부 기록합니다.

- `FriendListDebugLog` — 진단용 문서. `createdAt`에 14일 TTL 인덱스를 걸어 자동으로 정리됩니다.
- `FriendListDebugService.capture()` — 기존 로직을 감싸 성공/실패 양쪽을 기록합니다. 결과는 손대지 않고 그대로 반환하고, 예외는 그대로 다시 던집니다.
- `FriendController.getFriends` — 기존 본문을 `getFriendList()` private 함수로 **한 글자도 바꾸지 않고** 옮기고, 핸들러는 진단 서비스에 위임만 합니다. 되돌릴 때 이 커밋만 revert 하면 됩니다.

기존 코드 삭제·수정 없이 132줄 추가만 있습니다.

### 남기는 필드

`requesterUserId`(색인) · `requesterNickname` · `state` · `osType` · `appVersion` · `success` · `responseJson`(전문) · `friendCount` · `errorClass` · `errorMessage` · `stackTrace`(4000자 컷) · `createdAt`

## API 영향 없음

- `capture()`는 성공 시 결과를 그대로 반환하고, 실패 시 같은 예외를 그대로 다시 던집니다. 응답 본문·상태코드·에러코드가 달라지지 않습니다.

## 용량

친구 1명당 JSON 약 180B, 문서 고정 오버헤드 약 210B 기준입니다.

| 친구 수 | 문서 1건 |
| --- | --- |
| 0명 | 0.2 KB |
| 10명 | 2.0 KB |
| 50명 | 9.1 KB |

평균 10명(2.0KB) 가정 시 주간 1만 호출이면 20MB, 10만 호출이면 197MB입니다. 14일 TTL이라 그 이상 누적되지 않습니다. 예상보다 호출량이 많으면 TTL을 7일로 줄이면 됩니다.

## 조회

```
db.friend_list_debug_logs.find({ requesterUserId: "제보자id" }).sort({ createdAt: -1 })
db.friend_list_debug_logs.find({ success: false }).sort({ createdAt: -1 })
db.friend_list_debug_logs.find({ friendCount: 0 }).sort({ createdAt: -1 })
```

id는 ObjectId가 아니라 문자열로 저장해서 `ObjectId()`로 감쌀 필요가 없습니다.

## 범위 밖

- 친구 시간표 조회(`FriendTableController`)나 나머지 친구 API는 손대지 않았습니다.
- 켜고 끄는 설정값을 두지 않았습니다. 어차피 끄려면 재배포가 필요하고, 그때는 이 커밋을 revert 하는 게 맞습니다.
- 파드가 계속 재시작되는 문제 자체는 이 PR에서 다루지 않습니다. 다만 `deploy-api-prod.yml`(JVM)과 `deploy-api-prod-native.yml`(GraalVM native)이 같은 트리거·같은 OCIR 레포·같은 concurrency group을 쓰고 있어서, main에 푸시할 때마다 두 워크플로가 서로를 취소하며 경합합니다. 어느 이미지가 배포될지 비결정적이라 따로 확인이 필요해 보입니다.

## 정리 예정

원인 파악이 끝나면 이 커밋을 revert 해서 debug 패키지와 호출부를 함께 제거합니다. 쌓인 문서는 TTL로 14일 내에 자동 삭제되지만 컬렉션 자체는 남으므로, revert 배포 후 db.friend_list_debug_logs.drop() 으로 정리합니다.