### PR TITLE
추적 대상 유저의 API 호출 기록 추가

### DIFF
--- a/api/src/main/kotlin/filter/ApiDebugWebFilter.kt
+++ b/api/src/main/kotlin/filter/ApiDebugWebFilter.kt
@@ -1,0 +1,68 @@
+package com.wafflestudio.snutt.filter
+
+import com.wafflestudio.snutt.common.client.ClientInfo
+import com.wafflestudio.snutt.common.client.OsType
+import com.wafflestudio.snutt.config.USER_ATTRIBUTE_KEY
+import com.wafflestudio.snutt.debug.service.ApiDebugService
+import com.wafflestudio.snutt.users.data.User
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+/**
+ * 추적 대상 유저의 API 호출을 기록하는 임시 진단용 필터.
+ *
+ * [UserAuthenticationWebFilter] 가 채워 둔 유저 정보를 읽어야 하므로 그보다 안쪽(Order 5)에 둔다.
+ * 인증을 타지 않는 엔드포인트는 유저가 없어 기록되지 않으며, 그 덕분에 로그인 경로는 대상에서 빠진다.
+ *
+ * 기록은 응답 경로를 막지 않는다. [ApiDebugService.record] 가 별도 스코프에서 처리한다.
+ * 원인 파악이 끝나면 이 커밋을 되돌린다.
+ */
+@Component
+@Order(5)
+class ApiDebugWebFilter(
+    private val apiDebugService: ApiDebugService,
+) : WebFilter {
+    override fun filter(
+        exchange: ServerWebExchange,
+        chain: WebFilterChain,
+    ): Mono<Void> {
+        val startedAt = System.currentTimeMillis()
+
+        return chain
+            .filter(exchange)
+            .doOnSuccess { record(exchange, null, startedAt) }
+            .doOnError { record(exchange, it, startedAt) }
+    }
+
+    private fun record(
+        exchange: ServerWebExchange,
+        throwable: Throwable?,
+        startedAt: Long,
+    ) {
+        val user = exchange.attributes[USER_ATTRIBUTE_KEY] as? User ?: return
+        val userId = user.id ?: return
+        if (!apiDebugService.isTarget(userId)) return
+
+        val clientInfo = exchange.attributes[CLIENT_INFO_ATTRIBUTE_KEY] as? ClientInfo
+
+        apiDebugService.record(
+            userId = userId,
+            nickname = user.nickname,
+            method = exchange.request.method.name(),
+            path = exchange.request.path.value(),
+            query = exchange.request.uri.rawQuery,
+            status =
+                exchange.response.statusCode
+                    ?.value()
+                    .takeIf { throwable == null },
+            throwable = throwable,
+            osType = clientInfo?.osType?.name ?: OsType.UNKNOWN.name,
+            appVersion = clientInfo?.appVersion?.appVersion,
+            durationMs = System.currentTimeMillis() - startedAt,
+        )
+    }
+}

--- a/core/src/main/kotlin/debug/data/ApiDebugLog.kt
+++ b/core/src/main/kotlin/debug/data/ApiDebugLog.kt
@@ -1,0 +1,37 @@
+package com.wafflestudio.snutt.debug.data
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+
+/**
+ * [ApiDebugTarget] 에 등록된 유저의 API 호출 기록.
+ *
+ * 요청/응답 본문은 남기지 않는다. 목적이 "어떤 요청이 언제 왔고 어떻게 끝났는가"이고,
+ * 전 API의 본문을 담으면 로그인 경로의 액세스 토큰·개인정보가 그대로 쌓이기 때문이다.
+ * 특정 API의 본문이 필요해지면 그 엔드포인트만 따로 감싸는 편이 낫다.
+ *
+ * 임시 진단용이며, 원인 파악이 끝나면 이 커밋을 되돌린다.
+ */
+@Document("api_debug_logs")
+data class ApiDebugLog(
+    @Id
+    val id: String? = null,
+    @Indexed
+    val userId: String,
+    val nickname: String,
+    val method: String,
+    val path: String,
+    /** 쿼리 스트링 원본. 없으면 null */
+    val query: String?,
+    /** 성공 시 응답 상태 코드. 예외로 끝난 경우 null */
+    val status: Int?,
+    val errorClass: String?,
+    val errorMessage: String?,
+    val osType: String,
+    val appVersion: String?,
+    val durationMs: Long,
+    @Indexed(expireAfter = "14d")
+    val createdAt: Instant = Instant.now(),
+)

--- a/core/src/main/kotlin/debug/data/ApiDebugTarget.kt
+++ b/core/src/main/kotlin/debug/data/ApiDebugTarget.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.snutt.debug.data
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+
+/**
+ * API 호출 추적 대상 유저. 이 컬렉션에 문서를 넣으면 해당 유저의 모든 API 호출이
+ * [ApiDebugLog] 로 쌓인다. 재배포 없이 mongosh 로 추가·제거할 수 있다.
+ *
+ * 예) db.api_debug_targets.insertOne({ userId: "제보자id", memo: "친구 목록 미표시 제보", createdAt: new Date() })
+ *
+ * 임시 진단용이며, 원인 파악이 끝나면 이 커밋을 되돌린다.
+ */
+@Document("api_debug_targets")
+data class ApiDebugTarget(
+    @Id
+    val id: String? = null,
+    @Indexed(unique = true)
+    val userId: String,
+    /** 왜 넣었는지 메모 */
+    val memo: String? = null,
+    val createdAt: Instant = Instant.now(),
+)

--- a/core/src/main/kotlin/debug/repository/ApiDebugLogRepository.kt
+++ b/core/src/main/kotlin/debug/repository/ApiDebugLogRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.snutt.debug.repository
+
+import com.wafflestudio.snutt.debug.data.ApiDebugLog
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ApiDebugLogRepository : CoroutineCrudRepository<ApiDebugLog, String>

--- a/core/src/main/kotlin/debug/repository/ApiDebugTargetRepository.kt
+++ b/core/src/main/kotlin/debug/repository/ApiDebugTargetRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.snutt.debug.repository
+
+import com.wafflestudio.snutt.debug.data.ApiDebugTarget
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ApiDebugTargetRepository : CoroutineCrudRepository<ApiDebugTarget, String>

--- a/core/src/main/kotlin/debug/service/ApiDebugService.kt
+++ b/core/src/main/kotlin/debug/service/ApiDebugService.kt
@@ -1,0 +1,110 @@
+package com.wafflestudio.snutt.debug.service
+
+import com.wafflestudio.snutt.common.exception.SnuttException
+import com.wafflestudio.snutt.common.util.CoroutineUtils
+import com.wafflestudio.snutt.debug.data.ApiDebugLog
+import com.wafflestudio.snutt.debug.repository.ApiDebugLogRepository
+import com.wafflestudio.snutt.debug.repository.ApiDebugTargetRepository
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toSet
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * 추적 대상 유저의 API 호출을 [ApiDebugLog] 로 남기는 임시 진단용 서비스.
+ *
+ * 대상 목록은 `api_debug_targets` 컬렉션에서 읽어 메모리에 캐시하며, 재배포 없이
+ * mongosh 로 대상을 추가·제거할 수 있다. 원인 파악이 끝나면 이 커밋을 되돌린다.
+ */
+@Service
+class ApiDebugService(
+    private val apiDebugTargetRepository: ApiDebugTargetRepository,
+    private val apiDebugLogRepository: ApiDebugLogRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Volatile
+    private var targetUserIds: Set<String> = emptySet()
+
+    @Volatile
+    private var refreshedAt: Long = 0
+
+    private val refreshing = AtomicBoolean(false)
+
+    /**
+     * 기동 직후 첫 요청이 빈 캐시로 판별되는 것을 막기 위해 미리 한 번 읽어 둔다.
+     */
+    @EventListener(ApplicationReadyEvent::class)
+    fun warmUpTargets() {
+        refreshTargetsIfStale()
+    }
+
+    /**
+     * 추적 대상인지 판별한다. 매 요청마다 호출되므로 DB 를 조회하지 않고 캐시된 값만 본다.
+     * 캐시가 오래되었으면 갱신을 예약만 하고 즉시 반환해, 요청 지연을 만들지 않는다.
+     */
+    fun isTarget(userId: String): Boolean {
+        refreshTargetsIfStale()
+        return userId in targetUserIds
+    }
+
+    private fun refreshTargetsIfStale() {
+        val now = System.currentTimeMillis()
+        if (now - refreshedAt < REFRESH_INTERVAL_MS) return
+        if (!refreshing.compareAndSet(false, true)) return
+        // 조회에 실패하더라도 다음 주기까지는 재시도하지 않는다.
+        refreshedAt = now
+
+        CoroutineUtils.applicationScope.launch {
+            runCatching { apiDebugTargetRepository.findAll().map { it.userId }.toSet() }
+                .onSuccess { targetUserIds = it }
+                .onFailure { log.warn("API 추적 대상 목록 갱신 실패", it) }
+            refreshing.set(false)
+        }
+    }
+
+    /**
+     * 호출 기록을 남긴다. 응답 경로를 막지 않도록 별도 스코프에서 처리하며,
+     * 저장에 실패해도 예외를 밖으로 내보내지 않는다.
+     */
+    fun record(
+        userId: String,
+        nickname: String,
+        method: String,
+        path: String,
+        query: String?,
+        status: Int?,
+        throwable: Throwable?,
+        osType: String,
+        appVersion: String?,
+        durationMs: Long,
+    ) {
+        CoroutineUtils.applicationScope.launch {
+            runCatching {
+                apiDebugLogRepository.save(
+                    ApiDebugLog(
+                        userId = userId,
+                        nickname = nickname,
+                        method = method,
+                        path = path,
+                        query = query,
+                        status = status ?: (throwable as? SnuttException)?.error?.httpStatus?.value(),
+                        errorClass = throwable?.let { it::class.qualifiedName },
+                        errorMessage = throwable?.message,
+                        osType = osType,
+                        appVersion = appVersion,
+                        durationMs = durationMs,
+                    ),
+                )
+            }.onFailure { log.warn("API 추적 로그 저장 실패 (userId: $userId)", it) }
+        }
+    }
+
+    companion object {
+        private const val REFRESH_INTERVAL_MS = 60_000L
+    }
+}


### PR DESCRIPTION
특정 유저의 API 호출 흐름 전체를 확인할 수 있도록 한다. 요청이 서버에 도달하지 않는 경우까지 판별하기 위해서는 엔드포인트 단위 기록으로는 부족할 수 있기에 #543 과 함께 조사한다.

- api_debug_targets: 추적 대상 유저 컬렉션. mongosh 로 문서를 넣으면 되고 재배포 없이 대상을 추가·제거할 수 있다. 비어 있으면 아무것도 기록하지 않는다.
- api_debug_logs: userId · nickname · method · path · query · status · errorClass · errorMessage · osType · appVersion · durationMs · createdAt(14일 TTL). 요청/응답 본문은 남기지 않는다. 특정 api의 본문이 필요해지면 #543 처럼 그 앤드포인트만 조사한다.
- ApiDebugWebFilter: UserAuthenticationWebFilter 안쪽(Order 5)에 두어 유저를 식별한다. 인증을 타지 않는 엔드포인트는 기록되지 않는다.

대상 목록은 60초 주기로 메모리에 캐시해 매 요청 DB 조회를 피한다. 갱신 시에는 새 Set 을 만든 뒤 참조만 교체하므로 조회 중에도 이전 목록이 그대로 동작하고, 기동 직후 첫 요청이 빈 캐시를 보지 않도록 ApplicationReadyEvent 에서 미리 읽어 둔다. 
기록은 applicationScope 에서 처리해 응답 경로를 막지 않으며, createdAt 에 14일 TTL 인덱스를 걸어 자동 정리한다.

### 정리 예정
- 원인 파악 후 이 커밋을 revert 한다. 문서는 TTL로 14일 내에 자동 삭제되지만 컬렉션 자체는 남으므로, revert 배포 후 db.api_debug_logs.drop() / db.api_debug_targets.drop() 으로 정리한다.