### PR TITLE
5xx 응답을 일괄 로깅

### DIFF
--- a/api/src/main/kotlin/filter/ErrorWebFilter.kt
+++ b/api/src/main/kotlin/filter/ErrorWebFilter.kt
@@ -1,8 +1,11 @@
 package com.wafflestudio.snutt.filter
 
+import com.wafflestudio.snutt.common.client.ClientInfo
 import com.wafflestudio.snutt.common.exception.ErrorType
 import com.wafflestudio.snutt.common.exception.EvServiceProxyException
 import com.wafflestudio.snutt.common.exception.SnuttException
+import com.wafflestudio.snutt.config.USER_ATTRIBUTE_KEY
+import com.wafflestudio.snutt.users.data.User
 import kotlinx.coroutines.CancellationException
 import org.slf4j.LoggerFactory
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
@@ -11,6 +14,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.HandlerMapping
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
@@ -69,11 +73,12 @@ class ErrorWebFilter(
                     }
 
                     else -> {
-                        log.error(throwable.message, throwable)
                         httpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR
                         errorBody = makeErrorBody(SnuttException())
                     }
                 }
+
+                logErrorResponse(exchange, throwable, httpStatusCode, errorBody)
 
                 if (!exchange.response.isCommitted) {
                     exchange.response.statusCode = httpStatusCode
@@ -89,6 +94,45 @@ class ErrorWebFilter(
                     Mono.empty()
                 }
             }
+
+    /**
+     * 5xx 응답을 남긴다.
+     *
+     * 지금까지는 예상하지 못한 예외(else 분기)만 로그를 남겼다. [SnuttException] 중에도
+     * 500 을 내는 것이 있고 [EvServiceProxyException] 도 5xx 를 그대로 전달하는데,
+     * 그런 경우 500 이 나가면서 서버 로그에는 아무것도 남지 않았다.
+     *
+     * 4xx 는 남기지 않는다. 비밀번호 오류나 토큰 만료처럼 예상된 동작이라 애플리케이션
+     * 에러 로그의 대상이 아니고, 필요해지면 게이트웨이 접근 로그로 보는 편이 맞다.
+     *
+     * 경로는 path variable 이 치환되지 않은 매칭 패턴을 쓴다. 친구 초대 토큰처럼 경로에 담기는
+     * 값이 로그로 새어 나가지 않게 하기 위함이다.
+     */
+    private fun logErrorResponse(
+        exchange: ServerWebExchange,
+        throwable: Throwable,
+        httpStatusCode: HttpStatusCode,
+        errorBody: ErrorBody,
+    ) {
+        if (!httpStatusCode.is5xxServerError) return
+
+        val request = exchange.request
+        val path = exchange.attributes[HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE]?.toString() ?: request.path.value()
+        val userId = (exchange.attributes[USER_ATTRIBUTE_KEY] as? User)?.id
+        val appVersion = (exchange.attributes[CLIENT_INFO_ATTRIBUTE_KEY] as? ClientInfo)?.appVersion?.appVersion
+
+        log.error(
+            "{} {} -> {} errcode={} userId={} appVersion={} query={}",
+            request.method.name(),
+            path,
+            httpStatusCode.value(),
+            errorBody.errcode,
+            userId,
+            appVersion,
+            request.uri.rawQuery,
+            throwable,
+        )
+    }
 
     private fun makeErrorBody(exception: SnuttException): ErrorBody =
         ErrorBody(exception.error.errorCode, exception.title, exception.errorMessage, exception.displayMessage)


### PR DESCRIPTION
## 변경 사항

모든 5xx 응답에 대해 `ERROR` 레벨로 로그를 남깁니다.

기존에는 예상하지 못한 예외만 로그가 남아서, `SnuttException` 이나 `EvServiceProxyException` 으로 500 이 나가는 경우에는 서버 로그에 아무것도 남지 않았습니다.

어느 요청이 실패했는지 알 수 있도록 `userId` 와 쿼리 스트링도 함께 기록합니다.

```
ERROR GET /v1/friends -> 500 errcode=0 userId=68f1...abc appVersion=2.7.1 query=state=active
```

4xx 는 이번에 남기지 않습니다. 필요해지면 `INFO` 로 추가할 수 있는데, 지금 Loki 가 WARN 이상만 수집하고 있어서 그 설정을 먼저 고쳐야 합니다.